### PR TITLE
Support generating release notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+
+jdk:
+  - openjdk8
+
+cache:
+  directories:
+    - $HOME/.m2/repository

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# presto-release
+# Presto Release Tools
+[![Maven Central](https://img.shields.io/maven-central/v/com.facebook.presto/presto-release-tools.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:com.facebook.presto%20a:presto-release-tools)
+[![Build Status](https://travis-ci.org/prestodb/presto-release-tools.svg?branch=master)](https://travis-ci.org/prestodb/presto-release-tools)
+
+Tools to prepare Presto releases.
+
+## Generate Release Notes
+To collect and generate release notes, run the following commands in the presto repo.
+```
+curl -L -o /tmp/presto_release "https://oss.sonatype.org/service/local/artifact/maven/redirect?g=com.facebook.presto&a=presto-release-tools&v=LATEST&r=snapshots&c=executable&e=jar"
+chmod 755 /tmp/presto_release
+/tmp/presto_release release-notes --github-user <GITHUB_USER> --github-access-token <GITHUB_ACCESS_TOKEN>
+```
+
+The commands will create a local branch containing the collected release notes, and a pull request
+with description populated with missing release notes, release notes summary, and a list of
+commits within the release.

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
         <dependencies>
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
+                <artifactId>bootstrap</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
                 <artifactId>configuration</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
@@ -79,6 +85,12 @@
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>testing</artifactId>
                 <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>airline</artifactId>
+                <version>0.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,19 @@
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
+                <artifactId>http-client</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
                 <artifactId>log</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>json</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
     </parent>
 
     <groupId>com.facebook.presto</groupId>
-    <artifactId>presto-release-tools</artifactId>
+    <artifactId>presto-release-tools-root</artifactId>
     <version>0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>presto-release-tools</name>
+    <name>presto-release-tools-root</name>
     <description>Standard utilities to release Presto</description>
     <url>https://github.com/prestodb/presto-release-tools</url>
 
@@ -44,6 +44,32 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
     </properties>
+
+    <modules>
+        <module>presto-release-tools</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>configuration</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>log</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>testing</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.skife.maven</groupId>
                     <artifactId>really-executable-jar-maven-plugin</artifactId>
-                    <version>1.0.5</version>
+                    <version>1.5.0</version>
                 </plugin>
 
                 <plugin>
@@ -99,49 +99,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>com.facebook.presto</groupId>
-                <artifactId>presto-maven-plugin</artifactId>
-                <version>0.3</version>
-                <extensions>true</extensions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration combine.children="append">
-                    <includes>
-                        <include>**/Test*.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
-
-            <!-- Always build a jar with the test classes -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <!-- do not build an empty jar if the project is
-                         e.g. a pom project -->
-                    <skipIfEmpty>true</skipIfEmpty>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            <addClasspath>false</addClasspath>
-                        </manifest>
-                        <manifestEntries>
-                            <!-- This is actually the time when the build was done -->
-                            <Build-Time>${git.build.time}</Build-Time>
-                            <Git-Commit-Id>${git.commit.id}</Git-Commit-Id>
-                            <Implementation-Version>${project.version}-${git.commit.id.abbrev}</Implementation-Version>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <air.javadoc.lint>-missing</air.javadoc.lint>
 
         <dep.airlift.version>0.188</dep.airlift.version>
+        <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
     </properties>

--- a/presto-release-tools/pom.xml
+++ b/presto-release-tools/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 
@@ -53,6 +58,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -60,6 +70,11 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>airline</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-release-tools/pom.xml
+++ b/presto-release-tools/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-release-tools-root</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>presto-release-tools</artifactId>
+    <description>Presto Release Tool</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-release-tools/pom.xml
+++ b/presto-release-tools/pom.xml
@@ -24,7 +24,32 @@
 
         <dependency>
             <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
             <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>
@@ -45,6 +70,11 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/presto-release-tools/pom.xml
+++ b/presto-release-tools/pom.xml
@@ -14,6 +14,8 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <main-class>com.facebook.presto.release.PrestoReleaseService</main-class>
+        <process-name>${project.artifactId}</process-name>
     </properties>
 
     <dependencies>
@@ -104,5 +106,114 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- for assembly -->
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>launcher</artifactId>
+            <version>${dep.packaging.version}</version>
+            <classifier>bin</classifier>
+            <type>tar.gz</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>launcher</artifactId>
+            <version>${dep.packaging.version}</version>
+            <classifier>properties</classifier>
+            <type>tar.gz</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>executable</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>${main-class}</Main-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.skife.maven</groupId>
+                <artifactId>really-executable-jar-maven-plugin</artifactId>
+                <configuration>
+                    <flags>-Xmx1G</flags>
+                    <classifier>executable</classifier>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-launcher</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <includeArtifactIds>launcher</includeArtifactIds>
+                            <includeScope>provided</includeScope>
+                            <outputDirectory>${project.build.directory}/dependency/launcher</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bin</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <formats>
+                                <format>tar.gz</format>
+                            </formats>
+                            <descriptors>
+                                <descriptor>src/main/assembly/presto-release-tools.xml</descriptor>
+                            </descriptors>
+                            <finalName>presto-release-tools-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-release-tools/src/main/assembly/presto-release-tools.xml
+++ b/presto-release-tools/src/main/assembly/presto-release-tools.xml
@@ -1,0 +1,45 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>presto-server</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <files>
+        <file>
+            <source>../README.md</source>
+        </file>
+        <file>
+            <source>../NOTICE</source>
+        </file>
+    </files>
+
+    <dependencySets>
+        <!-- lib -->
+        <dependencySet>
+            <useProjectArtifact>true</useProjectArtifact>
+            <scope>runtime</scope>
+            <outputDirectory>lib</outputDirectory>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <!-- bin -->
+        <fileSet>
+            <directory>${project.build.directory}/dependency/launcher/bin</directory>
+            <includes>
+                <include>launcher.properties</include>
+            </includes>
+            <outputDirectory>bin</outputDirectory>
+            <filtered>true</filtered>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/launcher/bin</directory>
+            <includes>
+                <include>launcher</include>
+                <include>launcher.py</include>
+            </includes>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/AbstractAnnotatedProvider.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/AbstractAnnotatedProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+import javax.inject.Provider;
+
+import java.lang.annotation.Annotation;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Abstract base class for {@link Provider} that requires requires {@link Injector} and binds to a given annotation class.
+ */
+public abstract class AbstractAnnotatedProvider<T>
+        implements Provider<T>
+{
+    private final Class<? extends Annotation> annotation;
+    private Injector injector;
+
+    protected AbstractAnnotatedProvider(Class<? extends Annotation> annotation)
+    {
+        this.annotation = requireNonNull(annotation, "annotation is null");
+    }
+
+    @Inject
+    public final void setInjector(Injector injector)
+    {
+        this.injector = injector;
+    }
+
+    @Override
+    public final T get()
+    {
+        checkState(injector != null, "injector was not set");
+        return get(injector, annotation);
+    }
+
+    protected abstract T get(Injector injector, Class<? extends Annotation> annotation);
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/AbstractCommands.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/AbstractCommands.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.io.Files.asCharSource;
+import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractCommands
+{
+    private static final Logger log = Logger.get(AbstractCommands.class);
+
+    private final String executable;
+    private final Map<String, String> environment;
+    private final File directory;
+
+    public AbstractCommands(String executable, Map<String, String> environment, File directory)
+    {
+        this.executable = requireNonNull(executable, "executable is null");
+        this.environment = requireNonNull(environment, "environment is null");
+        this.directory = requireNonNull(directory, "directory is null");
+    }
+
+    protected String command(String... arguments)
+    {
+        return command(asList(arguments));
+    }
+
+    protected String command(List<String> arguments)
+    {
+        return command(
+                ImmutableList.<String>builder()
+                        .add(executable)
+                        .addAll(arguments)
+                        .build(),
+                environment,
+                directory);
+    }
+
+    protected static String command(List<String> command, Map<String, String> environment, File workingDirectory)
+    {
+        String commandLine = Joiner.on(" ").join(command);
+
+        try {
+            File logFile = Files.createTempFile("presto-release-log", "").toFile();
+            log.info(format("Running Command: %s; Log: %s", commandLine, logFile.getAbsolutePath()));
+
+            ProcessBuilder processBuilder = new ProcessBuilder(command);
+            Map<String, String> processEnvironment = processBuilder.environment();
+            environment.forEach(processEnvironment::put);
+            Process process = processBuilder.directory(workingDirectory).redirectOutput(logFile).start();
+
+            process.waitFor();
+
+            if (process.exitValue() != 0) {
+                readFromStream(process.getErrorStream()).ifPresent(log::error);
+                throw new RuntimeException("Command failed");
+            }
+
+            process.destroy();
+            process.waitFor();
+
+            log.info(format("Finished running command: %s", commandLine));
+            return asCharSource(logFile, UTF_8).read();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        catch (InterruptedException e) {
+            currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<String> readFromStream(InputStream stream)
+    {
+        try {
+            return Optional.of(CharStreams.toString(new InputStreamReader(stream, UTF_8)).trim());
+        }
+        catch (IOException t) {
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/ForPresto.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/ForPresto.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForPresto
+{
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/PrestoReleaseService.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/PrestoReleaseService.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release;
+
+import com.facebook.presto.release.tasks.GenerateReleaseNotesCommand;
+import io.airlift.airline.Cli;
+import io.airlift.airline.Help;
+
+public class PrestoReleaseService
+{
+    private PrestoReleaseService()
+    {
+    }
+
+    public static void main(String[] args)
+    {
+        Cli<Runnable> parser = Cli.<Runnable>builder("release")
+                .withDescription("Presto Release")
+                .withDefaultCommand(Help.class)
+                .withCommand(Help.class)
+                .withCommand(GenerateReleaseNotesCommand.class)
+                .build();
+        parser.parse(args).run();
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/ReleaseUtil.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/ReleaseUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release;
+
+import com.facebook.presto.release.git.Git;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class ReleaseUtil
+{
+    private ReleaseUtil() {}
+
+    /**
+     * Check for uncommitted changes, checkout and fast-forward master, and fetch upstream branches and tags.
+     */
+    public static void sanitizeRepository(Git git)
+    {
+        checkState(git.status("-s").isEmpty(), "Uncommitted local changes are not allowed.");
+        git.checkout(Optional.of("master"), Optional.empty());
+        git.fastForwardUpstream("master");
+        git.fetchUpstream(Optional.empty());
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/Actor.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/Actor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public class Actor
+{
+    private final String login;
+
+    @JsonCreator
+    public Actor(@JsonProperty("login") String login)
+    {
+        this.login = requireNonNull(login, "login is null");
+    }
+
+    public String getLogin()
+    {
+        return login;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/Commit.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/Commit.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class Commit
+{
+    private final String id;
+    private final String author;
+    private final String title;
+    private final List<PullRequest> associatedPullRequests;
+
+    @JsonCreator
+    public Commit(
+            @JsonProperty("oid") String id,
+            @JsonProperty("author") GitActor author,
+            @JsonProperty("message") String message,
+            @JsonProperty("associatedPullRequests") Map<String, List<PullRequest>> associatedPullRequests)
+    {
+        this.id = requireNonNull(id, "id is null");
+        this.author = requireNonNull(author.getName(), "author is null");
+        message = message.trim();
+        this.title = message.contains("\n") ? message.substring(0, message.indexOf('\n')) : message;
+        this.associatedPullRequests = ImmutableList.copyOf(associatedPullRequests.get("nodes"));
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public String getAuthor()
+    {
+        return author;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public List<PullRequest> getAssociatedPullRequests()
+    {
+        return associatedPullRequests;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/CommitHistory.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/CommitHistory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class CommitHistory
+{
+    private final PageInfo pageInfo;
+    private final List<Commit> commits;
+
+    @JsonCreator
+    public CommitHistory(
+            @JsonProperty("pageInfo") PageInfo pageInfo,
+            @JsonProperty("edges") List<Map<String, Commit>> edges)
+    {
+        this.pageInfo = requireNonNull(pageInfo, "pageInfo is null");
+        this.commits = edges.stream()
+                .map(entry -> entry.get("node"))
+                .collect(toImmutableList());
+    }
+
+    public PageInfo getPageInfo()
+    {
+        return pageInfo;
+    }
+
+    public List<Commit> getCommits()
+    {
+        return commits;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/FileRepositoryConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/FileRepositoryConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class FileRepositoryConfig
+{
+    private String upstreamName = "upstream";
+    private String originName = "origin";
+    private Optional<String> directory = Optional.empty();
+    private boolean checkDirectoryName = true;
+
+    @NotNull
+    public String getUpstreamName()
+    {
+        return upstreamName;
+    }
+
+    @Config("git.upstream-name")
+    public FileRepositoryConfig setUpstreamName(String upstreamName)
+    {
+        this.upstreamName = upstreamName;
+        return this;
+    }
+
+    @NotNull
+    public String getOriginName()
+    {
+        return originName;
+    }
+
+    @Config("git.origin-name")
+    public FileRepositoryConfig setOriginName(String originName)
+    {
+        this.originName = originName;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getDirectory()
+    {
+        return directory;
+    }
+
+    @Config("git.directory")
+    public FileRepositoryConfig setDirectory(String gitDirectory)
+    {
+        this.directory = Optional.ofNullable(gitDirectory);
+        return this;
+    }
+
+    public boolean isCheckDirectoryName()
+    {
+        return checkDirectoryName;
+    }
+
+    @Config("git.check-directory-name")
+    public FileRepositoryConfig setCheckDirectoryName(boolean checkDirectoryName)
+    {
+        this.checkDirectoryName = checkDirectoryName;
+        return this;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/ForGithub.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/ForGithub.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForGithub
+{
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/Git.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/Git.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import java.util.Optional;
+
+public interface Git
+{
+    GitRepository getRepository();
+
+    void add(String path);
+
+    void checkout(Optional<String> ref, Optional<String> createBranch);
+
+    void commit(String commitTitle);
+
+    void fastForwardUpstream(String ref);
+
+    void fetchUpstream(Optional<String> ref);
+
+    String log(String revisionRange, String... options);
+
+    void pushOrigin(String branch);
+
+    String status(String... options);
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitActor.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitActor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public class GitActor
+{
+    private final String name;
+
+    @JsonCreator
+    public GitActor(@JsonProperty("name") String name)
+    {
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitCommands.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitCommands.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.facebook.presto.release.AbstractCommands;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+public class GitCommands
+        extends AbstractCommands
+        implements Git
+{
+    private final GitRepository repository;
+
+    public GitCommands(GitRepository repository, GitConfig gitConfig)
+    {
+        super(
+                gitConfig.getExecutable(),
+                gitConfig.getSshKeyFile().map(s -> ImmutableMap.of("GIT_SSH_COMMAND", format("ssh -i %s", s))).orElseGet(ImmutableMap::of),
+                repository.getDirectory());
+
+        if (gitConfig.getSshKeyFile().isPresent()) {
+            checkArgument(gitConfig.getSshKeyFile().get().exists(), "ssh key file does not exists: %s", gitConfig.getSshKeyFile().get().getAbsolutePath());
+        }
+        this.repository = requireNonNull(repository, "repository is null");
+    }
+
+    @Override
+    public GitRepository getRepository()
+    {
+        return repository;
+    }
+
+    @Override
+    public void add(String path)
+    {
+        command("add", path);
+    }
+
+    @Override
+    public void checkout(Optional<String> ref, Optional<String> createBranch)
+    {
+        ImmutableList.Builder<String> arguments = ImmutableList.<String>builder().add("checkout");
+        createBranch.ifPresent(branch -> arguments.add("-b").add(branch));
+        ref.ifPresent(arguments::add);
+        command(arguments.build());
+    }
+
+    @Override
+    public void commit(String commitTitle)
+    {
+        command("commit", "-m", commitTitle);
+    }
+
+    @Override
+    public void fastForwardUpstream(String ref)
+    {
+        command("pull", "--ff-only", repository.getUpstreamName(), ref);
+    }
+
+    @Override
+    public void fetchUpstream(Optional<String> ref)
+    {
+        ImmutableList.Builder<String> arguments = ImmutableList.<String>builder()
+                .add("fetch")
+                .add(repository.getUpstreamName());
+        ref.ifPresent(arguments::add);
+        command(arguments.build());
+    }
+
+    @Override
+    public String log(String revisionRange, String... options)
+    {
+        return command(ImmutableList.<String>builder()
+                .add("log")
+                .add(revisionRange)
+                .addAll(asList(options))
+                .build());
+    }
+
+    @Override
+    public String status(String... options)
+    {
+        return command(ImmutableList.<String>builder()
+                .add("status")
+                .addAll(asList(options))
+                .build());
+    }
+
+    @Override
+    public void pushOrigin(String branch)
+    {
+        command("push", repository.getOriginName(), "-u", branch + ":" + branch, "-f");
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.Optional;
+
+public class GitConfig
+{
+    private String executable = "git";
+    private File sshKeyFile;
+
+    @NotNull
+    public String getExecutable()
+    {
+        return executable;
+    }
+
+    @Config("git.executable")
+    public GitConfig setExecutable(String executable)
+    {
+        this.executable = executable;
+        return this;
+    }
+
+    @NotNull
+    public Optional<File> getSshKeyFile()
+    {
+        return Optional.ofNullable(sshKeyFile);
+    }
+
+    @Config("git.ssh-key-file")
+    public GitConfig setSshKeyFile(File sshKeyFile)
+    {
+        this.sshKeyFile = sshKeyFile;
+        return this;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class GitModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(GitConfig.class);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepository.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepository.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import java.io.File;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class GitRepository
+{
+    private final String upstreamName;
+    private final String originName;
+    private final File directory;
+
+    private GitRepository(String upstreamName, String originName, File directory)
+    {
+        this.upstreamName = requireNonNull(upstreamName, "upstreamName is null");
+        this.originName = requireNonNull(originName, "originName is null");
+        this.directory = requireNonNull(directory, "directory is null");
+    }
+
+    public static GitRepository fromFile(String repositoryName, FileRepositoryConfig config)
+    {
+        return new GitRepository(
+                config.getUpstreamName(),
+                config.getOriginName(),
+                validateGitDirectory(
+                        config.getDirectory().orElse(System.getProperty("user.dir")),
+                        repositoryName,
+                        config.isCheckDirectoryName()));
+    }
+
+    public String getUpstreamName()
+    {
+        return upstreamName;
+    }
+
+    public String getOriginName()
+    {
+        return originName;
+    }
+
+    public File getDirectory()
+    {
+        return directory;
+    }
+
+    private static File validateGitDirectory(String gitDirectoryPath, String repositoryName, boolean checkGitDirectoryName)
+    {
+        File gitDirectory = new File(gitDirectoryPath);
+        if (checkGitDirectoryName) {
+            checkArgument(gitDirectory.getName().equals(repositoryName), "Directory name [%s] mismatches repository name [%s]", gitDirectory.getName(), repositoryName);
+        }
+        checkArgument(gitDirectory.exists(), "Does not exists: %s", gitDirectory.getAbsolutePath());
+        checkArgument(gitDirectory.isDirectory(), "Not a directory: %s", gitDirectory.getAbsolutePath());
+        return gitDirectory;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepositoryModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepositoryModule.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.facebook.presto.release.AbstractAnnotatedProvider;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Singleton;
+
+import java.lang.annotation.Annotation;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+public class GitRepositoryModule
+        implements Module
+{
+    private final Class<? extends Annotation> annotation;
+    private final String repositoryName;
+
+    public GitRepositoryModule(Class<? extends Annotation> annotation, String repositoryName)
+    {
+        this.annotation = requireNonNull(annotation, "annotation is null");
+        this.repositoryName = requireNonNull(repositoryName, "repositoryName is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileRepositoryConfig.class, annotation, repositoryName);
+        binder.bind(GitRepository.class).annotatedWith(annotation)
+                .toProvider(new GitRepositoryProvider(annotation, repositoryName))
+                .in(Singleton.class);
+        binder.bind(Git.class).annotatedWith(annotation)
+                .toProvider(new GitProvider(annotation))
+                .in(Singleton.class);
+    }
+
+    private static final class GitRepositoryProvider
+            extends AbstractAnnotatedProvider<GitRepository>
+    {
+        private final String repositoryName;
+
+        public GitRepositoryProvider(Class<? extends Annotation> annotation, String repositoryName)
+        {
+            super(annotation);
+            this.repositoryName = requireNonNull(repositoryName, "repositoryName is null");
+        }
+
+        @Override
+        protected GitRepository get(Injector injector, Class<? extends Annotation> annotation)
+        {
+            FileRepositoryConfig config = injector.getInstance(Key.get(FileRepositoryConfig.class, annotation));
+            return GitRepository.fromFile(repositoryName, config);
+        }
+    }
+
+    private static final class GitProvider
+            extends AbstractAnnotatedProvider<Git>
+    {
+        public GitProvider(Class<? extends Annotation> annotation)
+        {
+            super(annotation);
+        }
+
+        @Override
+        protected Git get(Injector injector, Class<? extends Annotation> annotation)
+        {
+            GitConfig gitConfig = injector.getInstance(GitConfig.class);
+            GitRepository repository = injector.getInstance(Key.get(GitRepository.class, annotation));
+            return new GitCommands(repository, gitConfig);
+        }
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubAction.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import java.util.List;
+
+public interface GithubAction
+{
+    /**
+     * List commits starting from {@code earliest}, inclusive, on {@code branch}.
+     */
+    List<Commit> listCommits(String branch, String earliest);
+
+    /**
+     * Create a pull request to merge from origin/branch to upstream/master.
+     */
+    PullRequest createPullRequest(String branch, String title, String body);
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubActionModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubActionModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static com.google.inject.Scopes.SINGLETON;
+
+public class GithubActionModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(GithubConfig.class);
+        httpClientBinder(binder).bindHttpClient("github", ForGithub.class);
+        binder.bind(GithubAction.class).to(GithubGraphQlAction.class).in(SINGLETON);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class GithubConfig
+{
+    private String user;
+    private String accessToken;
+
+    @NotNull
+    public String getUser()
+    {
+        return user;
+    }
+
+    @Config("github.user")
+    public GithubConfig setUser(String user)
+    {
+        this.user = user;
+        return this;
+    }
+
+    @NotNull
+    public String getAccessToken()
+    {
+        return accessToken;
+    }
+
+    @Config("github.access-token")
+    public GithubConfig setAccessToken(String accessToken)
+    {
+        this.accessToken = accessToken;
+        return this;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.json.JsonCodec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class GithubGraphQlAction
+        implements GithubAction
+{
+    private static final URI GRAPHQL_API_URI = URI.create("https://api.github.com/graphql");
+    private static final String PRESTO_REPOSITORY_ID = "MDEwOlJlcG9zaXRvcnk1MzQ5NTY1";
+    private static final String LIST_COMMITS_QUERY = "{\n" +
+            "    repository(owner: \"prestodb\", name: \"presto\") {\n" +
+            "        ref(qualifiedName: \"%s\") {\n" +
+            "            target {\n" +
+            "                ... on Commit {\n" +
+            "                    history(first: 100, after: %s) {\n" +
+            "                        pageInfo {\n" +
+            "                            hasNextPage\n" +
+            "                            endCursor\n" +
+            "                        }\n" +
+            "                        edges {\n" +
+            "                            node {\n" +
+            "                                oid\n" +
+            "                                message\n" +
+            "                                author {\n" +
+            "                                    name\n" +
+            "                                }\n" +
+            "                                associatedPullRequests(first: 10) {\n" +
+            "                                    nodes {\n" +
+            "                                      number\n" +
+            "                                      title\n" +
+            "                                      url\n" +
+            "                                      bodyText\n" +
+            "                                      author {\n" +
+            "                                          login\n" +
+            "                                      }\n" +
+            "                                      mergedBy {\n" +
+            "                                          ... on User {\n" +
+            "                                              name\n" +
+            "                                          }\n" +
+            "                                      }\n" +
+            "                                    }\n" +
+            "                                }\n" +
+            "                            }\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                }\n" +
+            "            }\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
+
+    private static final String CREATE_PULL_REQUEST_QUERY = "mutation($pr:CreatePullRequestInput!) {\n" +
+            "    createPullRequest(input:$pr) {\n" +
+            "        pullRequest {\n" +
+            "            number\n" +
+            "            title\n" +
+            "            url\n" +
+            "            bodyText\n" +
+            "            author {\n" +
+            "                login\n" +
+            "            }\n" +
+            "            mergedBy {\n" +
+            "                ... on User {\n" +
+            "                    name\n" +
+            "                }\n" +
+            "            }\n" +
+            "        }\n" +
+            "    }\n" +
+            "}";
+
+    private final HttpClient httpClient;
+    private final String user;
+    private final String accessToken;
+
+    @Inject
+    public GithubGraphQlAction(
+            @ForGithub HttpClient httpClient,
+            GithubConfig githubConfig)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.user = requireNonNull(githubConfig.getUser(), "githubUser is null");
+        this.accessToken = requireNonNull(githubConfig.getAccessToken(), "accessToken is null");
+    }
+
+    @Override
+    public List<Commit> listCommits(String branch, String earliest)
+    {
+        String current = null;
+        ImmutableList.Builder<Commit> commits = ImmutableList.builder();
+        TypeReference<Map<String, Map<String, Map<String, Map<String, Map<String, CommitHistory>>>>>> returnType = new TypeReference<Map<String, Map<String, Map<String, Map<String, Map<String, CommitHistory>>>>>>() {};
+
+        while (true) {
+            CommitHistory history = githubApi(format(LIST_COMMITS_QUERY, branch, current == null ? "null" : format("\"%s\"", current)), Optional.empty(), returnType)
+                    .get("data")
+                    .get("repository")
+                    .get("ref")
+                    .get("target")
+                    .get("history");
+            for (Commit commit : history.getCommits()) {
+                commits.add(commit);
+                if (commit.getId().equals(earliest)) {
+                    return commits.build();
+                }
+            }
+            if (!history.getPageInfo().isHasNextPage()) {
+                return commits.build();
+            }
+            current = history.getPageInfo().getEndCursor();
+        }
+    }
+
+    @Override
+    public PullRequest createPullRequest(String branch, String title, String body)
+    {
+        Map<String, Object> pullRequestVariable = ImmutableMap.<String, Object>builder()
+                .put("repositoryId", PRESTO_REPOSITORY_ID)
+                .put("baseRefName", "master")
+                .put("headRefName", format("%s:%s", user, branch))
+                .put("clientMutationId", randomUUID())
+                .put("maintainerCanModify", false)
+                .put("title", title)
+                .put("body", body)
+                .build();
+        String variables;
+        try {
+            variables = new ObjectMapper().writeValueAsString(ImmutableMap.of("pr", pullRequestVariable));
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return githubApi(CREATE_PULL_REQUEST_QUERY, Optional.of(variables), new TypeReference<Map<String, Map<String, Map<String, PullRequest>>>>() {})
+                .get("data")
+                .get("createPullRequest")
+                .get("pullRequest");
+    }
+
+    private <T> T githubApi(String query, Optional<String> variables, TypeReference<T> typeReference)
+    {
+        String body = httpClient.execute(
+                preparePost()
+                        .setUri(GRAPHQL_API_URI)
+                        .addHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .addHeader(ACCEPT, APPLICATION_JSON)
+                        .addHeader(AUTHORIZATION, "token " + accessToken)
+                        .addHeader(USER_AGENT, "Presto")
+                        .setBodyGenerator(jsonBodyGenerator(GraphQlQuery.CODEC, new GraphQlQuery(query, variables)))
+                        .build(),
+                createStringResponseHandler()).getBody();
+
+        try {
+            return new ObjectMapper().readValue(body, typeReference);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class GraphQlQuery
+    {
+        private static final JsonCodec<GraphQlQuery> CODEC = jsonCodec(GraphQlQuery.class);
+
+        private final String query;
+        private final Optional<String> variables;
+
+        @JsonCreator
+        public GraphQlQuery(
+                @JsonProperty("query") String query,
+                @JsonProperty("variables") Optional<String> variables)
+        {
+            this.query = requireNonNull(query, "query is null");
+            this.variables = requireNonNull(variables, "variables is null");
+        }
+
+        @JsonProperty
+        public String getQuery()
+        {
+            return query;
+        }
+
+        @JsonProperty
+        public Optional<String> getVariables()
+        {
+            return variables;
+        }
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/PageInfo.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/PageInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public class PageInfo
+{
+    private final boolean hasNextPage;
+    private final String endCursor;
+
+    @JsonCreator
+    public PageInfo(
+            @JsonProperty("hasNextPage") boolean hasNextPage,
+            @JsonProperty("endCursor") String endCursor)
+    {
+        this.hasNextPage = hasNextPage;
+        this.endCursor = requireNonNull(endCursor, "endCursor is null");
+    }
+
+    public boolean isHasNextPage()
+    {
+        return hasNextPage;
+    }
+
+    public String getEndCursor()
+    {
+        return endCursor;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/PullRequest.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/PullRequest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class PullRequest
+{
+    private final int id;
+    private final String title;
+    private final String url;
+    private final String description;
+    private final String authorLogin;
+    private final Optional<String> mergedBy;
+
+    @JsonCreator
+    public PullRequest(
+            @JsonProperty("number") int id,
+            @JsonProperty("title") String title,
+            @JsonProperty("url") String url,
+            @JsonProperty("bodyText") String description,
+            @JsonProperty("author") Actor author,
+            @JsonProperty("mergedBy") User mergedBy)
+    {
+        this.id = id;
+        this.title = requireNonNull(title, "title is null");
+        this.url = requireNonNull(url, "url is null");
+        this.description = requireNonNull(description, "description is null");
+        this.authorLogin = requireNonNull(author.getLogin(), "authorLogin is null");
+        this.mergedBy = Optional.ofNullable(mergedBy).flatMap(User::getName);
+    }
+
+    public int getId()
+    {
+        return id;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public String getAuthorLogin()
+    {
+        return authorLogin;
+    }
+
+    public Optional<String> getMergedBy()
+    {
+        return mergedBy;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PullRequest that = (PullRequest) obj;
+        return id == that.id &&
+                Objects.equals(title, that.title) &&
+                Objects.equals(url, that.url) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(authorLogin, that.authorLogin) &&
+                Objects.equals(mergedBy, that.mergedBy);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(id, title, url, description, authorLogin, mergedBy);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/User.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/User.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public class User
+{
+    private final Optional<String> name;
+
+    @JsonCreator
+    public User(@JsonProperty("name") String name)
+    {
+        this.name = Optional.ofNullable(name);
+    }
+
+    public Optional<String> getName()
+    {
+        return name;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersion.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersion.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.maven;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
+
+public class MavenVersion
+{
+    private static final Pattern RELEASE_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)");
+    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)-SNAPSHOT");
+    private final int versionNumber;
+
+    private MavenVersion(int versionNumber)
+    {
+        checkArgument(versionNumber > 0, "Expect positive version number, found: %s", versionNumber);
+        this.versionNumber = versionNumber;
+    }
+
+    public static MavenVersion fromDirectory(File directory)
+    {
+        checkArgument(directory.exists(), "Does not exists: %s", directory.getAbsolutePath());
+        checkArgument(directory.isDirectory(), "Not a directory: %s", directory.getAbsolutePath());
+        return fromPom(Paths.get(directory.getAbsolutePath(), "pom.xml").toFile());
+    }
+
+    public static MavenVersion fromPom(File file)
+    {
+        try {
+            Map<String, Object> elements = new XmlMapper().readValue(file, new TypeReference<Map<String, Object>>() {});
+            checkArgument(elements.containsKey("version"), "No version tag found in %s", file.getAbsolutePath());
+            return fromSnapshotVersion((String) elements.get("version"));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static MavenVersion fromReleaseVersion(String version)
+    {
+        Matcher matcher = RELEASE_VERSION_PATTERN.matcher(version);
+        checkArgument(matcher.matches(), "Invalid release version: %s", version);
+        return new MavenVersion(parseInt(matcher.group(1)));
+    }
+
+    public static MavenVersion fromSnapshotVersion(String version)
+    {
+        Matcher matcher = SNAPSHOT_VERSION_PATTERN.matcher(version);
+        checkArgument(matcher.matches(), "Invalid snapshot version: %s", version);
+        return new MavenVersion(parseInt(matcher.group(1)));
+    }
+
+    public MavenVersion getLastVersion()
+    {
+        return new MavenVersion(versionNumber - 1);
+    }
+
+    public String getVersion()
+    {
+        return format("0.%s", versionNumber);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesCommand.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.release.ForPresto;
+import com.facebook.presto.release.git.GitModule;
+import com.facebook.presto.release.git.GitRepositoryModule;
+import com.facebook.presto.release.git.GithubActionModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+@Command(name = "release-notes", description = "Presto release notes generator")
+public class GenerateReleaseNotesCommand
+        implements Runnable
+{
+    private static final Logger log = Logger.get(GenerateReleaseNotesCommand.class);
+
+    @Option(name = "--github-user", title = "Github username", required = true)
+    public String githubUser;
+
+    @Option(name = "--github-access-token", title = "Github Personal Access Token", required = true)
+    public String githubAccessToken;
+
+    @Option(name = "--version", title = "Release version")
+    public String version;
+
+    @Option(name = "--upstream-name", title = "Presto repo upstream name")
+    public String gitUpstreamName;
+
+    @Option(name = "--origin-name", title = "Presto repo origin name")
+    public String gitOriginName;
+
+    @Option(name = "--directory", title = "Presto repo directory")
+    public String gitDirectory;
+
+    @Option(name = "--check-directory-name", title = "Check whether the git directory name is presto")
+    public String gitCheckDirectoryName;
+
+    @Option(name = "--git-executable", title = "Git executable")
+    public String gitExecutable;
+
+    @Option(name = "--git-ssh-key-file", title = "Git SSH key file")
+    public String gitSshKeyFile;
+
+    @Override
+    public void run()
+    {
+        System.setProperty("github.user", githubUser);
+        System.setProperty("github.access-token", githubAccessToken);
+        if (version != null) {
+            System.setProperty("release-notes.version", version);
+        }
+        if (gitUpstreamName != null) {
+            System.setProperty("presto.git.upstream-name", gitUpstreamName);
+        }
+        if (gitOriginName != null) {
+            System.setProperty("presto.git.origin-name", gitOriginName);
+        }
+        if (gitDirectory != null) {
+            System.setProperty("presto.git.directory", gitDirectory);
+        }
+        if (gitCheckDirectoryName != null) {
+            System.setProperty("presto.git.check-directory-name", gitCheckDirectoryName);
+        }
+        if (gitExecutable != null) {
+            System.setProperty("git.executable", gitExecutable);
+        }
+        if (gitSshKeyFile != null) {
+            System.setProperty("git.ssh-key-file", gitSshKeyFile);
+        }
+
+        Bootstrap app = new Bootstrap(ImmutableList.of(
+                new GitModule(),
+                new GitRepositoryModule(ForPresto.class, "presto"),
+                new GithubActionModule(),
+                new GenerateReleaseNotesModule()));
+
+        Injector injector = null;
+        try {
+            injector = app.strictConfig().initialize();
+            injector.getInstance(GenerateReleaseNotesTask.class).run();
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+        finally {
+            if (injector != null) {
+                try {
+                    injector.getInstance(LifeCycleManager.class).stop();
+                }
+                catch (Exception e) {
+                    log.error(e);
+                }
+            }
+        }
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class GenerateReleaseNotesConfig
+{
+    private Optional<String> version = Optional.empty();
+
+    @NotNull
+    public Optional<String> getVersion()
+    {
+        return version;
+    }
+
+    @Config("release-notes.version")
+    public GenerateReleaseNotesConfig setVersion(String version)
+    {
+        this.version = Optional.ofNullable(version);
+        return this;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.Scopes.SINGLETON;
+
+public class GenerateReleaseNotesModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(GenerateReleaseNotesConfig.class);
+        binder.bind(GenerateReleaseNotesTask.class).in(SINGLETON);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -1,0 +1,460 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.release.ForPresto;
+import com.facebook.presto.release.git.Commit;
+import com.facebook.presto.release.git.Git;
+import com.facebook.presto.release.git.GitRepository;
+import com.facebook.presto.release.git.GithubAction;
+import com.facebook.presto.release.git.PullRequest;
+import com.facebook.presto.release.maven.MavenVersion;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.release.ReleaseUtil.sanitizeRepository;
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ExtractionStatus.EXPECT_DASHES_OR_RELEASE_NOTE;
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ExtractionStatus.EXPECT_LINE;
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ExtractionStatus.EXPECT_SECTION_HEADER;
+import static com.google.common.base.Functions.identity;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.io.Files.asCharSink;
+import static com.google.common.io.Files.asCharSource;
+import static java.lang.Character.toUpperCase;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.nCopies;
+import static java.util.Collections.sort;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.DOTALL;
+import static java.util.regex.Pattern.MULTILINE;
+import static java.util.stream.Collectors.joining;
+
+public class GenerateReleaseNotesTask
+        implements Runnable
+{
+    private static final Logger log = Logger.get(GenerateReleaseNotesTask.class);
+
+    public static final String RELEASE_NOTES_FILE = "presto-docs/src/main/sphinx/release/release-%s.rst";
+    public static final String RELEASE_NOTES_LIST_FILE = "presto-docs/src/main/sphinx/release.rst";
+
+    private static final Pattern IGNORED_COMMITS_PATTERN = Pattern.compile("\\[maven-release-plugin]|add release note(s)? for|prepare for next development iteration", CASE_INSENSITIVE);
+    private static final Pattern NO_RELEASE_NOTE_PATTERN = Pattern.compile("== no release note(s)? ==", CASE_INSENSITIVE);
+    private static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\w*(.*)$", CASE_INSENSITIVE + MULTILINE + DOTALL);
+    private static final Pattern HEADER_PATTERN = Pattern.compile("(.*) change(s)$", CASE_INSENSITIVE);
+    private static final Pattern KNOWN_HEADER_PATTERN = Pattern.compile("(general|security|jdbc driver|web ui|.* connector|verifier|resource groups|spi)$", CASE_INSENSITIVE);
+    private static final Pattern DASHES = Pattern.compile("-+$");
+
+    private final Git git;
+    private final GitRepository repository;
+    private final GithubAction githubAction;
+    private final Optional<MavenVersion> version;
+
+    @Inject
+    public GenerateReleaseNotesTask(
+            @ForPresto Git git,
+            GithubAction githubAction,
+            GenerateReleaseNotesConfig config)
+    {
+        this.git = requireNonNull(git, "git is null");
+        this.repository = requireNonNull(git.getRepository(), "repository is null");
+        this.githubAction = requireNonNull(githubAction, "githubAction is null");
+        this.version = config.getVersion().map(MavenVersion::fromReleaseVersion);
+    }
+
+    @Override
+    public void run()
+    {
+        sanitizeRepository(git);
+        MavenVersion version = this.version.orElseGet(() -> MavenVersion.fromDirectory(repository.getDirectory()).getLastVersion());
+
+        log.info("Release version: %s, Last Version: %s", version.getVersion(), version.getLastVersion().getVersion());
+        List<String> commitIds = Splitter.on("\n")
+                .trimResults()
+                .omitEmptyStrings()
+                .splitToList(git.log(
+                        format(
+                                "%s/release-%s..%s/release-%s",
+                                repository.getUpstreamName(),
+                                version.getLastVersion().getVersion(),
+                                repository.getUpstreamName(),
+                                version.getVersion()),
+                        "--format=%H",
+                        "--date-order"));
+
+        log.info("Fetching Github commits");
+        List<Commit> commits = githubAction.listCommits("release-" + version.getVersion(), commitIds.get(commitIds.size() - 1));
+
+        log.info("Fetched %s commits", commits.size());
+        commits = commits.stream()
+                .filter(commit -> !IGNORED_COMMITS_PATTERN.matcher(commit.getTitle()).find())
+                .collect(toImmutableList());
+
+        log.info("Processing %s commits", commits.size());
+        List<PullRequest> pullRequests = commits.stream()
+                .flatMap(commit -> commit.getAssociatedPullRequests().stream())
+                .distinct()
+                .collect(toImmutableList());
+        Map<PullRequest, Optional<List<ReleaseNoteItem>>> releaseNoteItems = pullRequests.stream()
+                .collect(toImmutableMap(identity(), this::extractReleaseNotes));
+
+        log.info("Collecting author information");
+        Map<String, String> userByLogin = new HashMap<>();
+        for (Commit commit : commits) {
+            for (PullRequest pullRequest : commit.getAssociatedPullRequests()) {
+                userByLogin.putIfAbsent(pullRequest.getAuthorLogin(), commit.getAuthor());
+            }
+        }
+        userByLogin = ImmutableMap.copyOf(userByLogin);
+
+        log.info("Generating release notes");
+        String releaseNotes = generateReleaseNotes(version, releaseNoteItems);
+        String releaseNotesSummary = format(
+                "%s\n%s\n%s",
+                generateMissingReleaseNotes(releaseNoteItems, commits, userByLogin),
+                generateExtractedReleaseNotes(releaseNoteItems, userByLogin),
+                generateCommits(commits));
+
+        log.info("Generating release notes pull request");
+        String releaseNotesBranch = "release-notes-" + version.getVersion();
+        createReleaseNotesCommit(version.getVersion(), releaseNotesBranch, releaseNotes);
+        git.pushOrigin(releaseNotesBranch);
+
+        PullRequest releaseNotesPullRequest = githubAction.createPullRequest(releaseNotesBranch, format("Add release notes for %s", version.getVersion()), releaseNotesSummary);
+        log.info("Release notes pull request created: %s", releaseNotesPullRequest.getUrl());
+    }
+
+    enum ExtractionStatus
+    {
+        EXPECT_SECTION_HEADER,
+        EXPECT_DASHES_OR_RELEASE_NOTE,
+        EXPECT_LINE,
+    }
+
+    private Optional<List<ReleaseNoteItem>> extractReleaseNotes(PullRequest pullRequest)
+    {
+        if (NO_RELEASE_NOTE_PATTERN.matcher(pullRequest.getDescription()).find()) {
+            return Optional.of(ImmutableList.of());
+        }
+
+        Matcher matcher = RELEASE_NOTE_PATTERN.matcher(pullRequest.getDescription() + "\n");
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+
+        // Use a state machine to extract release notes
+        ImmutableList.Builder<ReleaseNoteItem> releaseNoteItems = ImmutableList.builder();
+        String section = null;
+        StringBuilder currentNote = null;
+        ExtractionStatus status = EXPECT_SECTION_HEADER;
+
+        for (String line : Splitter.on("\n").trimResults().split(matcher.group(2))) {
+            switch (status) {
+                case EXPECT_SECTION_HEADER:
+                    if (line.isEmpty()) {
+                        continue;
+                    }
+                    section = extractSection(line).orElse(null);
+                    if (section == null) {
+                        log.error(format("Bad release notes for PR #%s: expect section header, found [%s]", pullRequest.getId(), line));
+                        return Optional.empty();
+                    }
+                    status = EXPECT_DASHES_OR_RELEASE_NOTE;
+                    break;
+
+                case EXPECT_DASHES_OR_RELEASE_NOTE:
+                    if (DASHES.matcher(line).matches()) {
+                        continue;
+                    }
+                    if (line.isEmpty()) {
+                        log.error(format("Bad release notes for PR #%s: no release note for section [%s]", pullRequest.getId(), section));
+                        return Optional.empty();
+                    }
+                    if (!line.startsWith("*")) {
+                        log.error(format("Bad release notes for PR #%s at [%s]: release note starts without asterisk (*)", pullRequest.getId(), line));
+                        return Optional.empty();
+                    }
+                    currentNote = new StringBuilder(line.substring(2).trim());
+                    status = EXPECT_LINE;
+                    break;
+
+                case EXPECT_LINE:
+                    if (line.isEmpty()) {
+                        releaseNoteItems.add(new ReleaseNoteItem(section, currentNote.toString()));
+                        status = EXPECT_SECTION_HEADER;
+                    }
+                    else if (line.startsWith("*")) {
+                        releaseNoteItems.add(new ReleaseNoteItem(section, currentNote.toString()));
+                        currentNote = new StringBuilder(line.substring(2).trim());
+                    }
+                    else {
+                        Optional<String> possibleSection = extractSection(line);
+                        if (possibleSection.isPresent()) {
+                            releaseNoteItems.add(new ReleaseNoteItem(section, currentNote.toString()));
+                            section = possibleSection.get();
+                            status = EXPECT_DASHES_OR_RELEASE_NOTE;
+                        }
+                        else {
+                            currentNote.append(" ").append(line);
+                        }
+                    }
+                    break;
+            }
+        }
+        return Optional.of(releaseNoteItems.build());
+    }
+
+    private Optional<String> extractSection(String line)
+    {
+        Matcher matcher = HEADER_PATTERN.matcher(line);
+        if (matcher.matches()) {
+            return Optional.of(matcher.group(1).toLowerCase(ENGLISH));
+        }
+
+        matcher = KNOWN_HEADER_PATTERN.matcher(line);
+        if (matcher.matches()) {
+            return Optional.of(line);
+        }
+
+        return Optional.empty();
+    }
+
+    private String generateReleaseNotes(MavenVersion version, Map<PullRequest, Optional<List<ReleaseNoteItem>>> releaseNoteItems)
+    {
+        StringBuilder document = new StringBuilder(format("=============\nRelease %s\n=============\n\n", version.getVersion()));
+
+        Multimap<String, ReleaseNoteItem> releaseNotesByCategory = releaseNoteItems.values().stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .flatMap(List::stream)
+                .collect(toImmutableListMultimap(ReleaseNoteItem::getSection, identity()));
+
+        List<String> categories = new ArrayList<>(releaseNotesByCategory.keySet());
+        categories.sort(new CategoryComparator());
+
+        for (String category : categories) {
+            String header = category + " Changes";
+            document.append(header)
+                    .append("\n")
+                    .append(Joiner.on("").join(nCopies(header.length(), "_")));
+            for (ReleaseNoteItem item : releaseNotesByCategory.get(category)) {
+                document.append("\n").append(item.getFormatted("*", 0));
+            }
+            document.append("\n\n");
+        }
+        return document.toString().trim() + "\n";
+    }
+
+    private String generateMissingReleaseNotes(Map<PullRequest, Optional<List<ReleaseNoteItem>>> releaseNoteItems, List<Commit> commits, Map<String, String> userByLogin)
+    {
+        List<PullRequest> pullRequestsMissingReleaseNotes = releaseNoteItems.entrySet().stream()
+                .filter(entry -> !entry.getValue().isPresent())
+                .map(Map.Entry::getKey)
+                .collect(toImmutableList());
+        List<Commit> dissociatedCommits = commits.stream()
+                .filter(commit -> commit.getAssociatedPullRequests().isEmpty())
+                .collect(toImmutableList());
+
+        Map<String, StringBuilder> missingByAuthor = new TreeMap<>();
+        for (PullRequest pullRequest : pullRequestsMissingReleaseNotes) {
+            String author = userByLogin.get(pullRequest.getAuthorLogin());
+            missingByAuthor.putIfAbsent(author, new StringBuilder("## ").append(author).append("\n"));
+            StringBuilder missing = missingByAuthor.get(author);
+            missing.append("- [ ] ")
+                    .append(pullRequest.getUrl())
+                    .append(" ")
+                    .append(pullRequest.getTitle());
+            if (pullRequest.getMergedBy().isPresent()) {
+                missing.append(" (Merged by: ")
+                        .append(pullRequest.getMergedBy().get())
+                        .append(")");
+            }
+            missing.append("\n");
+        }
+        for (Commit commit : dissociatedCommits) {
+            String author = commit.getAuthor();
+            missingByAuthor.putIfAbsent(author, new StringBuilder("## ").append(author).append("\n"));
+            missingByAuthor.get(author)
+                    .append("- [ ] ")
+                    .append(commit.getId())
+                    .append(" ")
+                    .append(commit.getTitle())
+                    .append("\n");
+        }
+        return "# Missing Release Notes\n" +
+                missingByAuthor.values().stream()
+                        .map(StringBuilder::toString)
+                        .collect(joining("\n"));
+    }
+
+    private String generateExtractedReleaseNotes(Map<PullRequest, Optional<List<ReleaseNoteItem>>> releaseNoteItems, Map<String, String> userByLogin)
+    {
+        StringBuilder document = new StringBuilder("# Extracted Release Notes\n");
+
+        List<PullRequest> pullRequests = new ArrayList<>(releaseNoteItems.keySet());
+        sort(pullRequests, Comparator.comparing(PullRequest::getId));
+        for (PullRequest pullRequest : pullRequests) {
+            Optional<List<ReleaseNoteItem>> releaseNotes = releaseNoteItems.get(pullRequest);
+            if (!releaseNotes.isPresent() || releaseNotes.get().isEmpty()) {
+                continue;
+            }
+
+            document.append("- #")
+                    .append(pullRequest.getId())
+                    .append(" (Author: ")
+                    .append(userByLogin.get(pullRequest.getAuthorLogin()))
+                    .append("): ")
+                    .append(pullRequest.getTitle())
+                    .append("\n");
+            for (ReleaseNoteItem item : releaseNotes.get()) {
+                document.append(item.getFormatted("-", 2)).append("\n");
+            }
+        }
+        return document.toString();
+    }
+
+    private String generateCommits(List<Commit> commits)
+    {
+        return "# All Commits\n" +
+                commits.stream()
+                        .map(commit -> format("- %s %s (%s)", commit.getId(), commit.getTitle(), commit.getAuthor()))
+                        .collect(joining("\n"));
+    }
+
+    private void createReleaseNotesCommit(String version, String branch, String releaseNotes)
+    {
+        git.checkout(Optional.empty(), Optional.of(branch));
+
+        try {
+            String gitDirectory = repository.getDirectory().getAbsolutePath();
+            asCharSink(Paths.get(gitDirectory, format(RELEASE_NOTES_FILE, version)).toFile(), UTF_8).write(releaseNotes);
+            List<String> lines = new LinkedList<>(asCharSource(Paths.get(gitDirectory, RELEASE_NOTES_LIST_FILE).toFile(), UTF_8).readLines());
+            lines.add(7, format("    release/release-%s", version));
+            asCharSink(Paths.get(gitDirectory, RELEASE_NOTES_LIST_FILE).toFile(), UTF_8).write(Joiner.on("\n").join(lines) + "\n");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        git.add(".");
+        git.commit(format("Add release notes for %s", version));
+    }
+
+    public static class CategoryComparator
+            implements Comparator<String>
+    {
+        private static final List<Pattern> CATEGORY_ORDERS = ImmutableList.<Pattern>builder()
+                .add(Pattern.compile("General"))
+                .add(Pattern.compile("Security"))
+                .add(Pattern.compile("JDBC Driver"))
+                .add(Pattern.compile(".* Connector"))
+                .add(Pattern.compile("Web UI"))
+                .add(Pattern.compile("Verifier"))
+                .add(Pattern.compile("Resource Groups"))
+                .add(Pattern.compile("SPI"))
+                .build();
+
+        @Override
+        public int compare(String category1, String category2)
+        {
+            int order1 = getCategoryOrder(category1);
+            int order2 = getCategoryOrder(category2);
+            if (order1 != order2) {
+                return Integer.compare(order1, order2);
+            }
+            return category1.compareTo(category2);
+        }
+
+        private int getCategoryOrder(String category)
+        {
+            return IntStream.range(0, CATEGORY_ORDERS.size())
+                    .filter(i -> CATEGORY_ORDERS.get(i).matcher(category).matches())
+                    .findFirst()
+                    .orElse(CATEGORY_ORDERS.size());
+        }
+    }
+
+    private static class ReleaseNoteItem
+    {
+        private static final Set<String> ALL_UPPER_WORDS = ImmutableSet.of("jdbc", "spi", "ui");
+
+        private final String section;
+        private final String line;
+
+        public ReleaseNoteItem(String section, String line)
+        {
+            this.section = formatCategory(requireNonNull(section, "section is null"));
+            checkArgument(!Strings.isNullOrEmpty(line), "line is null or empty");
+            this.line = toUpperCase(line.charAt(0)) + line.substring(1);
+        }
+
+        public String getSection()
+        {
+            return section;
+        }
+
+        public String getFormatted(String marking, int indent)
+        {
+            return format("%s%s %s%s", Joiner.on("").join(nCopies(indent, " ")), marking, line, line.endsWith(".") ? "" : ".");
+        }
+
+        private static String formatCategory(String category)
+        {
+            StringBuilder formatted = new StringBuilder();
+            Scanner scanner = new Scanner(category);
+            while (scanner.hasNext()) {
+                String word = scanner.next();
+                if (ALL_UPPER_WORDS.contains(word)) {
+                    formatted.append(word.toUpperCase(ENGLISH));
+                }
+                else {
+                    formatted.append(toUpperCase(word.charAt(0))).append(word.substring(1));
+                }
+                if (scanner.hasNext()) {
+                    formatted.append(" ");
+                }
+            }
+            return formatted.toString();
+        }
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGit.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGit.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class MockGit
+        implements Git
+{
+    private final GitRepository repository;
+
+    public MockGit(GitRepository repository)
+    {
+        this.repository = requireNonNull(repository, "repository is null");
+    }
+
+    @Override
+    public GitRepository getRepository()
+    {
+        return repository;
+    }
+
+    @Override
+    public void add(String path)
+    {
+    }
+
+    @Override
+    public void checkout(Optional<String> ref, Optional<String> createBranch)
+    {
+    }
+
+    @Override
+    public void commit(String commitTitle)
+    {
+    }
+
+    @Override
+    public void fastForwardUpstream(String branch)
+    {
+    }
+
+    @Override
+    public void fetchUpstream(Optional<String> branch)
+    {
+    }
+
+    @Override
+    public String log(String revisionRange, String... options)
+    {
+        return "96d1a0420c46ed6a2442a3598dad5e7c9599e9c1\neacf13484139a85c53901f2045578c659a65a5b2";
+    }
+
+    @Override
+    public void pushOrigin(String branch)
+    {
+    }
+
+    @Override
+    public String status(String... options)
+    {
+        return "";
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class MockGithubAction
+        implements GithubAction
+{
+    private final List<Commit> commits;
+    private PullRequest pullRequest;
+
+    public MockGithubAction(List<Commit> commits)
+    {
+        this.commits = ImmutableList.copyOf(commits);
+    }
+
+    @Override
+    public List<Commit> listCommits(String latest, String earliest)
+    {
+        return commits;
+    }
+
+    @Override
+    public PullRequest createPullRequest(String branch, String title, String body)
+    {
+        checkState(pullRequest == null, "Can only create one pull request");
+        pullRequest = new PullRequest(0, title, "", body, new Actor("test"), null);
+        return pullRequest;
+    }
+
+    public PullRequest getCreatedPullRequest()
+    {
+        return pullRequest;
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/TestFileRepositoryConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/TestFileRepositoryConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestFileRepositoryConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(FileRepositoryConfig.class)
+                .setUpstreamName("upstream")
+                .setOriginName("origin")
+                .setDirectory(null)
+                .setCheckDirectoryName(true));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("git.upstream-name", "u")
+                .put("git.origin-name", "o")
+                .put("git.directory", "/tmp/presto")
+                .put("git.check-directory-name", "false")
+                .build();
+        FileRepositoryConfig expected = new FileRepositoryConfig()
+                .setUpstreamName("u")
+                .setOriginName("o")
+                .setDirectory("/tmp/presto")
+                .setCheckDirectoryName(false);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/TestGitConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/TestGitConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestGitConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(GitConfig.class)
+                .setExecutable("git")
+                .setSshKeyFile(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("git.executable", "/bin/git")
+                .put("git.ssh-key-file", "~/.ssh/id_rsa")
+                .build();
+        GitConfig expected = new GitConfig()
+                .setExecutable("/bin/git")
+                .setSshKeyFile(new File("~/.ssh/id_rsa"));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/TestGithubConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/TestGithubConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.git;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestGithubConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(GithubConfig.class)
+                .setUser(null)
+                .setAccessToken(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("github.user", "bot")
+                .put("github.access-token", "abc")
+                .build();
+        GithubConfig expected = new GithubConfig()
+                .setUser("bot")
+                .setAccessToken("abc");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestMavenVersion.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestMavenVersion.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.maven;
+
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import static com.facebook.presto.release.maven.MavenVersion.fromDirectory;
+import static com.facebook.presto.release.maven.MavenVersion.fromPom;
+import static com.facebook.presto.release.maven.MavenVersion.fromReleaseVersion;
+import static com.facebook.presto.release.maven.MavenVersion.fromSnapshotVersion;
+import static org.testng.Assert.assertEquals;
+
+public class TestMavenVersion
+{
+    @Test
+    public void testReleaseVersion()
+    {
+        assertEquals(fromReleaseVersion("0.230").getVersion(), "0.230");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid release version: 0\\.230-SNAPSHOT")
+    public void testInvalidReleaseVersion()
+    {
+        fromReleaseVersion("0.230-SNAPSHOT");
+    }
+
+    @Test
+    public void testSnapshotVersion()
+    {
+        assertEquals(fromSnapshotVersion("0.230-SNAPSHOT").getVersion(), "0.230");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid snapshot version: 0\\.230")
+    public void testInvalidSnapshotVersion()
+    {
+        fromSnapshotVersion("0.230");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid release version: 0\\.0")
+    public void testZeroVersion()
+    {
+        fromReleaseVersion("0.0");
+    }
+
+    @Test
+    public void testFromPom()
+    {
+        File pomFile = new File(Resources.getResource("pom.xml").getFile());
+        assertEquals(fromPom(pomFile).getVersion(), "0.232");
+    }
+
+    @Test
+    public void testFromDirectory()
+    {
+        File pomFile = new File(Resources.getResource("pom.xml").getFile()).getParentFile();
+        assertEquals(fromDirectory(pomFile).getVersion(), "0.232");
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestGenerateReleaseNotesConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(GenerateReleaseNotesConfig.class)
+                .setVersion(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("release-notes.version", "0.231")
+                .build();
+        GenerateReleaseNotesConfig expected = new GenerateReleaseNotesConfig()
+                .setVersion("0.231");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.facebook.presto.release.git.Actor;
+import com.facebook.presto.release.git.Commit;
+import com.facebook.presto.release.git.FileRepositoryConfig;
+import com.facebook.presto.release.git.GitActor;
+import com.facebook.presto.release.git.GitRepository;
+import com.facebook.presto.release.git.MockGit;
+import com.facebook.presto.release.git.MockGithubAction;
+import com.facebook.presto.release.git.PullRequest;
+import com.facebook.presto.release.git.User;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.RELEASE_NOTES_FILE;
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.RELEASE_NOTES_LIST_FILE;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.io.Files.asCharSource;
+import static com.google.common.io.Files.copy;
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestGenerateReleaseNotesTask
+{
+    private static final String RESOURCE_DIRECTORY = "release-notes-test";
+    private static final String VERSION = "0.231";
+    private static final String COMMIT_HASH_PREFIX = Joiner.on("").join(nCopies(30, "a"));
+
+    private static final Person USER1 = new Person("user1@gmail.com", "user1");
+    private static final Person USER2 = new Person("user2@gmail.com", "user2");
+    private static final Person USER3 = new Person("user3@gmail.com", "user3");
+
+    private static final AtomicInteger PullRequestId = new AtomicInteger(1);
+    private static final AtomicInteger commitId = new AtomicInteger(1);
+
+    private static final List<Commit> COMMITS = ImmutableList.<Commit>builder()
+            .addAll(createCommits("release notes 1", USER1, USER1, true, 1))
+            .addAll(createCommits("release notes 2", USER2, USER1, true, 2))
+            .addAll(createCommits("no release note", USER3, USER1, true, 1))
+            .addAll(createCommits("no release notes", USER1, USER2, true, 2))
+            .addAll(createCommits("missing release note", USER3, USER2, true, 2))
+            .addAll(createCommits("missing section header 1", USER2, USER1, true, 1))
+            .addAll(createCommits("missing section header 2", USER1, USER1, true, 1))
+            .addAll(createCommits("missing section header 3", USER1, USER1, true, 1))
+            .addAll(createCommits("missing asterisk", USER3, USER2, true, 1))
+            .addAll(createCommits("disassociated commit", USER3, USER2, false, 1))
+            .build();
+
+    private File workingDirectory;
+    private File releaseNotesListFile;
+    private File releaseNotesFile;
+    private MockGithubAction githubAction;
+
+    @BeforeClass
+    public void setup()
+            throws IOException
+    {
+        this.workingDirectory = createTempDir();
+        this.releaseNotesListFile = Paths.get(workingDirectory.getAbsolutePath(), RELEASE_NOTES_LIST_FILE).toFile();
+        this.releaseNotesFile = Paths.get(workingDirectory.getAbsolutePath(), format(RELEASE_NOTES_FILE, VERSION)).toFile();
+
+        checkState(releaseNotesListFile.getParentFile().mkdirs(), "Failed to create directory: %s", releaseNotesListFile.getParentFile());
+        checkState(releaseNotesFile.getParentFile().mkdirs(), "Failed to create directory: %s", releaseNotesFile.getParentFile());
+        copy(new File(getTestResource("release.rst").getFile()), releaseNotesListFile);
+    }
+
+    @AfterClass
+    public void teardown()
+            throws IOException
+    {
+        deleteRecursively(workingDirectory.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testGenerateReleaseNotes()
+            throws Exception
+    {
+        GenerateReleaseNotesTask task = initializeTask(COMMITS);
+        task.run();
+
+        assertEquals(asCharSource(releaseNotesListFile, UTF_8).read(), getTestResourceContent("release_expected.rst"));
+        assertEquals(asCharSource(releaseNotesFile, UTF_8).read(), getTestResourceContent("release-0.231_expected.rst"));
+        assertEquals(githubAction.getCreatedPullRequest().getDescription(), getTestResourceContent("description_expected.txt"));
+    }
+
+    private GenerateReleaseNotesTask initializeTask(List<Commit> commits)
+    {
+        this.githubAction = new MockGithubAction(commits);
+        return new GenerateReleaseNotesTask(
+                new MockGit(GitRepository.fromFile(
+                        workingDirectory.getName(),
+                        new FileRepositoryConfig().setDirectory(workingDirectory.getAbsolutePath()))),
+                githubAction,
+                new GenerateReleaseNotesConfig().setVersion(VERSION));
+    }
+
+    private static PullRequest loadPullRequest(String title, Person author, Person mergedBy)
+    {
+        int id = PullRequestId.getAndIncrement();
+        String fileName = title.replace(' ', '_') + ".txt";
+
+        try {
+            return new PullRequest(
+                    id,
+                    title,
+                    format("https://github.com/prestodb/presto/pull/%s", id),
+                    getTestResourceContent("pr", fileName),
+                    author.getActor(),
+                    mergedBy.getUser());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static List<Commit> createCommits(String title, Person author, Person mergedBy, boolean associateWithPullRequest, int commitCount)
+    {
+        List<PullRequest> associatedPullRequests = associateWithPullRequest ? ImmutableList.of(loadPullRequest(title, author, mergedBy)) : ImmutableList.of();
+
+        return IntStream.range(0, commitCount).mapToObj(
+                i -> new Commit(
+                        format("%s%02d", COMMIT_HASH_PREFIX, commitId.getAndIncrement()),
+                        author.getGitActor(),
+                        format("%s - commit #%s", title, i + 1),
+                        ImmutableMap.of("nodes", associatedPullRequests)))
+                .collect(toImmutableList());
+    }
+
+    private static URL getTestResource(String... path)
+    {
+        return Resources.getResource(Paths.get(RESOURCE_DIRECTORY, path).toString());
+    }
+
+    private static String getTestResourceContent(String... path)
+            throws IOException
+    {
+        return Resources.toString(getTestResource(path), UTF_8);
+    }
+
+    private static class Person
+    {
+        private final String login;
+        private final String name;
+
+        public Person(String login, String name)
+        {
+            this.login = requireNonNull(login, "login is null");
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        public Actor getActor()
+        {
+            return new Actor(login);
+        }
+
+        public User getUser()
+        {
+            return new User(name);
+        }
+
+        public GitActor getGitActor()
+        {
+            return new GitActor(name);
+        }
+    }
+}

--- a/presto-release-tools/src/test/resources/pom.xml
+++ b/presto-release-tools/src/test/resources/pom.xml
@@ -1,0 +1,1565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.airlift</groupId>
+        <artifactId>airbase</artifactId>
+        <version>95</version>
+    </parent>
+
+    <groupId>com.facebook.presto</groupId>
+    <artifactId>presto-root</artifactId>
+    <version>0.232-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>presto-root</name>
+    <description>Presto</description>
+    <url>https://github.com/prestodb/presto</url>
+
+    <inceptionYear>2012</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/prestodb/presto.git</connection>
+        <url>https://github.com/prestodb/presto</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <air.main.basedir>${project.basedir}</air.main.basedir>
+
+        <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
+        <air.check.skip-pmd>true</air.check.skip-pmd>
+        <air.check.skip-jacoco>true</air.check.skip-jacoco>
+        <air.checkstyle.config-file>src/checkstyle/presto-checks.xml</air.checkstyle.config-file>
+
+        <air.java.version>1.8.0-151</air.java.version>
+        <air.maven.version>3.3.9</air.maven.version>
+
+        <dep.antlr.version>4.7.1</dep.antlr.version>
+        <dep.airlift.version>0.187</dep.airlift.version>
+        <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
+        <dep.slice.version>0.36</dep.slice.version>
+        <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
+        <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>
+        <dep.okhttp.version>3.9.0</dep.okhttp.version>
+        <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
+        <dep.drift.version>1.22</dep.drift.version>
+        <dep.joda.version>2.10</dep.joda.version>
+        <dep.tempto.version>1.50</dep.tempto.version>
+        <dep.testng.version>6.10</dep.testng.version>
+        <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
+        <dep.logback.version>1.2.3</dep.logback.version>
+        <dep.parquet.version>1.10.0</dep.parquet.version>
+        <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
+        <dep.asm.version>6.2.1</dep.asm.version>
+        <dep.gcs.version>1.9.17</dep.gcs.version>
+
+        <!--
+          America/Bahia_Banderas has:
+           - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
+           - DST (e.g. at 2017-04-02 02:00:00 clocks turned forward 1 hour; 2017-10-29 02:00:00 clocks turned backward 1 hour)
+           - has forward offset change on first day of epoch (1970-01-01 00:00:00 clocks turned forward 1 hour)
+           - had forward change at midnight (1970-01-01 00:00:00 clocks turned forward 1 hour)
+          -->
+        <air.test.timezone>America/Bahia_Banderas</air.test.timezone>
+        <air.test.parallel>methods</air.test.parallel>
+        <air.test.thread-count>2</air.test.thread-count>
+        <air.test.jvmsize>2g</air.test.jvmsize>
+
+        <air.javadoc.lint>-missing</air.javadoc.lint>
+    </properties>
+
+    <modules>
+        <module>presto-atop</module>
+        <module>presto-spi</module>
+        <module>presto-array</module>
+        <module>presto-cache</module>
+        <module>presto-jmx</module>
+        <module>presto-record-decoder</module>
+        <module>presto-kafka</module>
+        <module>presto-redis</module>
+        <module>presto-accumulo</module>
+        <module>presto-cassandra</module>
+        <module>presto-blackhole</module>
+        <module>presto-memory</module>
+        <module>presto-orc</module>
+        <module>presto-parquet</module>
+        <module>presto-rcfile</module>
+        <module>presto-hive</module>
+        <module>presto-hive-hadoop2</module>
+        <module>presto-hive-metastore</module>
+        <module>presto-teradata-functions</module>
+        <module>presto-example-http</module>
+        <module>presto-local-file</module>
+        <module>presto-tpch</module>
+        <module>presto-tpcds</module>
+        <module>presto-raptor</module>
+        <module>presto-base-jdbc</module>
+        <module>presto-testing-docker</module>
+        <module>presto-mysql</module>
+        <module>presto-postgresql</module>
+        <module>presto-redshift</module>
+        <module>presto-sqlserver</module>
+        <module>presto-mongodb</module>
+        <module>presto-bytecode</module>
+        <module>presto-client</module>
+        <module>presto-parser</module>
+        <module>presto-main</module>
+        <module>presto-ml</module>
+        <module>presto-geospatial</module>
+        <module>presto-geospatial-toolkit</module>
+        <module>presto-benchmark</module>
+        <module>presto-tests</module>
+        <module>presto-product-tests</module>
+        <module>presto-jdbc</module>
+        <module>presto-pinot</module>
+        <module>presto-pinot-toolkit</module>
+        <module>presto-cli</module>
+        <module>presto-benchmark-driver</module>
+        <module>presto-server</module>
+        <module>presto-server-rpm</module>
+        <module>presto-docs</module>
+        <module>presto-verifier</module>
+        <module>presto-testing-server-launcher</module>
+        <module>presto-plugin-toolkit</module>
+        <module>presto-resource-group-managers</module>
+        <module>presto-password-authenticators</module>
+        <module>presto-session-property-managers</module>
+        <module>presto-benchto-benchmarks</module>
+        <module>presto-thrift-connector-api</module>
+        <module>presto-thrift-testing-server</module>
+        <module>presto-thrift-connector</module>
+        <module>presto-matching</module>
+        <module>presto-memory-context</module>
+        <module>presto-proxy</module>
+        <module>presto-kudu</module>
+        <module>presto-elasticsearch</module>
+        <module>presto-sql-function</module>
+        <module>presto-expressions</module>
+        <module>presto-benchmark-runner</module>
+        <module>presto-spark-classloader-interface</module>
+        <module>presto-spark</module>
+        <module>presto-spark-package</module>
+        <module>presto-spark-launcher</module>
+        <module>presto-spark-testing</module>
+        <module>presto-release</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-testing-docker</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spi</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-resource-group-managers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-resource-group-managers</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-password-authenticators</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-session-property-managers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-array</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-plugin-toolkit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-record-decoder</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-orc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-parquet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-rcfile</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-hive</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-hive-hadoop2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-example-http</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-local-file</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-hive</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.teradata</groupId>
+                <artifactId>re2j-td</artifactId>
+                <version>1.4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-tpch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-tpcds</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-blackhole</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-memory</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-base-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-pinot</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-pinot-toolkit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-mysql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-geospatial</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-geospatial-toolkit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-raptor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-cache</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-cli</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-bytecode</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-parser</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-parser</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-main</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-main</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-hive-metastore</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-hive-metastore</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-matching</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-memory-context</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-expressions</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-server</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-server-rpm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-tests</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-benchmark</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-benchto-benchmarks</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-product-tests</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-sqlserver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-sql-function</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spark-classloader-interface</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spark</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-afterburner</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.hadoop</groupId>
+                <artifactId>hadoop-apache2</artifactId>
+                <version>2.7.4-5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.hive</groupId>
+                <artifactId>hive-apache</artifactId>
+                <version>1.2.2-2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.orc</groupId>
+                <artifactId>orc-protobuf</artifactId>
+                <version>7</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-thrift-connector-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-thrift-connector-api</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-thrift-testing-server</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-thrift-connector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-thrift-connector</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.hive</groupId>
+                <artifactId>hive-dwrf</artifactId>
+                <version>0.8.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>0.13</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>log</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>log-manager</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>json</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>security</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>units</artifactId>
+                <version>1.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>concurrent</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>configuration</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>discovery</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>testing</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>node</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>bootstrap</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>event</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>http-server</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>jaxrs</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>jaxrs-testing</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>jmx</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>trace-token</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>dbpool</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>jmx-http</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>http-client</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>stats</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>joni</artifactId>
+                <version>2.1.5.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>joda-to-java-time-bridge</artifactId>
+                <version>3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-api</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-client</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-codec</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-protocol</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-server</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-transport-netty</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift.tpch</groupId>
+                <artifactId>tpch</artifactId>
+                <version>0.10</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.teradata.tpcds</groupId>
+                <artifactId>tpcds</artifactId>
+                <version>1.2</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${dep.asm.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${dep.asm.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
+                <version>${dep.asm.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${dep.asm.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.4.197</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.sonatype.aether</groupId>
+                <artifactId>aether-api</artifactId>
+                <version>1.13.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift.resolver</groupId>
+                <artifactId>resolver</artifactId>
+                <version>1.4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>airline</artifactId>
+                <version>0.8</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.openjdk.jol</groupId>
+                <artifactId>jol-core</artifactId>
+                <version>0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>13.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>it.unimi.dsi</groupId>
+                <artifactId>fastutil</artifactId>
+                <version>6.5.9</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.thirdparty</groupId>
+                <artifactId>libsvm</artifactId>
+                <version>3.18.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>5.1.48</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.2.5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.pcollections</groupId>
+                <artifactId>pcollections</artifactId>
+                <version>2.1.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${dep.antlr.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>7.0.0.jre8</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jline</groupId>
+                <artifactId>jline</artifactId>
+                <version>2.14.6</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.fusesource.jansi</groupId>
+                        <artifactId>jansi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi</artifactId>
+                <version>2.78</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-core</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-sqlobject</artifactId>
+                <version>${dep.jdbi3.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${dep.okhttp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-urlconnection</artifactId>
+                <version>${dep.okhttp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>mockwebserver</artifactId>
+                <version>${dep.okhttp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.jsonwebtoken</groupId>
+                <artifactId>jjwt</artifactId>
+                <version>0.9.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>0.9.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>net.sf.opencsv</groupId>
+                <artifactId>opencsv</artifactId>
+                <version>2.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift.discovery</groupId>
+                <artifactId>discovery-server</artifactId>
+                <version>1.30</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.alluxio</groupId>
+                <artifactId>alluxio-shaded-client</artifactId>
+                <version>2.1.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>${dep.aws-sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-glue</artifactId>
+                <version>${dep.aws-sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-s3</artifactId>
+                <version>${dep.aws-sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>util</artifactId>
+                <version>${dep.gcs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>gcsio</artifactId>
+                <version>${dep.gcs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>util-hadoop</artifactId>
+                <version>hadoop2-${dep.gcs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.cloud.bigdataoss</groupId>
+                <artifactId>gcs-connector</artifactId>
+                <version>hadoop2-${dep.gcs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>testing-mysql-server-5</artifactId>
+                <version>${dep.testing-mysql-server-5.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>testing-mysql-server-base</artifactId>
+                <version>${dep.testing-mysql-server-5.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>testing-postgresql-server</artifactId>
+                <version>9.6.3-4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.12</artifactId>
+                <version>1.1.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.7.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>1.3.5-4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.4.13</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>jline</artifactId>
+                        <groupId>jline</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jgrapht</groupId>
+                <artifactId>jgrapht-core</artifactId>
+                <version>0.9.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>redis.clients</groupId>
+                <artifactId>jedis</artifactId>
+                <version>2.6.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.orange.redis-embedded</groupId>
+                <artifactId>embedded-redis</artifactId>
+                <version>0.6</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prestodb.tempto</groupId>
+                <artifactId>tempto-core</artifactId>
+                <version>${dep.tempto.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.datastax.cassandra</groupId>
+                        <artifactId>cassandra-driver-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prestodb.tempto</groupId>
+                <artifactId>tempto-ldap</artifactId>
+                <version>${dep.tempto.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.datastax.cassandra</groupId>
+                        <artifactId>cassandra-driver-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prestodb.tempto</groupId>
+                <artifactId>tempto-kafka</artifactId>
+                <version>${dep.tempto.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.datastax.cassandra</groupId>
+                        <artifactId>cassandra-driver-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prestodb.tempto</groupId>
+                <artifactId>tempto-runner</artifactId>
+                <version>${dep.tempto.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.datastax.cassandra</groupId>
+                        <artifactId>cassandra-driver-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.hive</groupId>
+                <artifactId>hive-apache-jdbc</artifactId>
+                <version>0.13.1-5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.esri.geometry</groupId>
+                <artifactId>esri-geometry-api</artifactId>
+                <version>2.2.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>7.2.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.lucene</groupId>
+                        <artifactId>lucene-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.locationtech.jts</groupId>
+                <artifactId>jts-core</artifactId>
+                <version>1.16.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.anarres.lzo</groupId>
+                <artifactId>lzo-hadoop</artifactId>
+                <version>1.0.5</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.cassandra</groupId>
+                <artifactId>cassandra-server</artifactId>
+                <version>2.1.16-1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.cassandra</groupId>
+                <artifactId>cassandra-driver</artifactId>
+                <version>3.1.4-1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.pinot</groupId>
+                <artifactId>pinot-driver</artifactId>
+                <version>0.1.1</version>
+            </dependency>
+
+            <!-- force newer version to be used for dependencies -->
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.22.0-GA</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.starburstdata</groupId>
+                <artifactId>starburst-spotify-docker-client</artifactId>
+                <version>8.11.7-0.6</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.jodah</groupId>
+                <artifactId>failsafe</artifactId>
+                <version>2.0.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.spark</groupId>
+                <artifactId>spark-core</artifactId>
+                <version>2.0.2-4</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.antlr</groupId>
+                    <artifactId>antlr4-maven-plugin</artifactId>
+                    <version>${dep.antlr.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>antlr4</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <visitor>true</visitor>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.skife.maven</groupId>
+                    <artifactId>really-executable-jar-maven-plugin</artifactId>
+                    <version>1.0.5</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.8</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.6.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>io.airlift.maven.plugins</groupId>
+                    <artifactId>sphinx-maven-plugin</artifactId>
+                    <version>2.1</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.facebook.drift</groupId>
+                    <artifactId>drift-maven-plugin</artifactId>
+                    <version>${dep.drift.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.gaul</groupId>
+                    <artifactId>modernizer-maven-plugin</artifactId>
+                    <configuration>
+                        <violationsFiles>
+                            <violationsFile>${air.main.basedir}/src/modernizer/violations.xml</violationsFile>
+                        </violationsFiles>
+                        <exclusionPatterns>
+                            <exclusionPattern>org/joda/time/.*</exclusionPattern>
+                        </exclusionPatterns>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <configuration>
+                        <rules>
+                            <requireUpperBoundDeps>
+                                <excludes combine.children="append">
+                                    <!-- TODO: fix this in Airlift resolver -->
+                                    <exclude>org.codehaus.plexus:plexus-utils</exclude>
+                                    <exclude>com.google.guava:guava</exclude>
+                                </excludes>
+                            </requireUpperBoundDeps>
+                        </rules>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <configuration>
+                        <preparationGoals>clean verify -DskipTests</preparationGoals>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${dep.nexus-staging-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-maven-plugin</artifactId>
+                <version>0.3</version>
+                <extensions>true</extensions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration combine.children="append">
+                    <fork>false</fork>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.children="append">
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/Benchmark*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*jmhTest*.java</exclude>
+                        <exclude>**/*jmhType*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Always build a jar with the test classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!-- do not build an empty jar if the project is
+                         e.g. a pom project -->
+                    <skipIfEmpty>true</skipIfEmpty>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addClasspath>false</addClasspath>
+                        </manifest>
+                        <manifestEntries>
+                            <!-- This is actually the time when the build was done -->
+                            <Build-Time>${git.build.time}</Build-Time>
+                            <Git-Commit-Id>${git.commit.id}</Git-Commit-Id>
+                            <Implementation-Version>${project.version}-${git.commit.id.abbrev}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>tests-with-dependencies</id>
+            <!--
+                Assembles an uber (fat) jar that includes the entire "test" scope classpath for a module.
+
+                For example after running:
+
+                ./mvnw clean install -P tests-with-dependencies -pl presto-geospatial
+
+                The uber jar that contains the entire "test" scope class path of the "presto-geospatial"
+                is created and placed to that modules target directory:
+
+                ./presto-geospatial/target/presto-geospatial-0.197-SNAPSHOT-tests-with-dependencies.jar
+
+                Now using this jar we can easily run any benchmark from that module via command line:
+
+                java \
+                  -cp ./presto-geospatial/target/presto-geospatial-*-tests-with-dependencies.jar \
+                  com.facebook.presto.plugin.geospatial.BenchmarkSTIntersects
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptor>${air.main.basedir}/src/assembly/tests-with-dependencies.xml</descriptor>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>deploy-to-ossrh</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
@@ -1,0 +1,35 @@
+# Missing Release Notes
+## user1
+- [ ] https://github.com/prestodb/presto/pull/7 missing section header 2 (Merged by: user1)
+- [ ] https://github.com/prestodb/presto/pull/8 missing section header 3 (Merged by: user1)
+
+## user2
+- [ ] https://github.com/prestodb/presto/pull/6 missing section header 1 (Merged by: user1)
+
+## user3
+- [ ] https://github.com/prestodb/presto/pull/5 missing release note (Merged by: user2)
+- [ ] https://github.com/prestodb/presto/pull/9 missing asterisk (Merged by: user2)
+- [ ] aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13 disassociated commit - commit #1
+
+# Extracted Release Notes
+- #1 (Author: user1): release notes 1
+  - Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+  - Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.
+- #2 (Author: user2): release notes 2
+  - Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
+  - Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
+
+# All Commits
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01 release notes 1 - commit #1 (user1)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa02 release notes 2 - commit #1 (user2)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa03 release notes 2 - commit #2 (user2)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa04 no release note - commit #1 (user3)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05 no release notes - commit #1 (user1)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa06 no release notes - commit #2 (user1)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa07 missing release note - commit #1 (user3)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa08 missing release note - commit #2 (user3)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa09 missing section header 1 - commit #1 (user2)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa10 missing section header 2 - commit #1 (user1)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11 missing section header 3 - commit #1 (user1)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12 missing asterisk - commit #1 (user3)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13 disassociated commit - commit #1 (user3)

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_asterisk.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_asterisk.txt
@@ -1,0 +1,4 @@
+== RELEASE NOTES ==
+
+General Changes
+added configs to use common HTTPS settings for internal communications

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_release_note.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_release_note.txt
@@ -1,0 +1,8 @@
+Some
+PR
+description
+but
+no
+release
+notes
+section.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_1.txt
@@ -1,0 +1,8 @@
+Some PR description.
+
+== RELEASE NOTES ==
+
+* Introduced new cache module to allow using local disk for to cache files from remote file systems.
+
+Raptor Changes
+* Allow Raptor to read data from HDFS while caching the files on local disks.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_2.txt
@@ -1,0 +1,8 @@
+Some PR description.
+
+== RELEASE NOTES ==
+
+Cache Changes
+* Introduced new cache module to allow using local disk for to cache files from remote file systems.
+
+* Allow Raptor to read data from HDFS while caching the files on local disks.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_3.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_3.txt
@@ -1,0 +1,6 @@
+Some PR description.
+
+== RELEASE NOTES ==
+
+Introduced new cache module to allow using local disk for to cache files from remote file systems.
+Allow Raptor to read data from HDFS while caching the files on local disks.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_note.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_note.txt
@@ -1,0 +1,3 @@
+Some PR description.
+
+== NO RELEASE NOTE ==

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_notes.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_notes.txt
@@ -1,0 +1,1 @@
+== NO RELEASE NOTES ==

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
@@ -1,0 +1,5 @@
+== RELEASE NOTES ==
+
+Raptor Changes
+* Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+* Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
@@ -1,0 +1,8 @@
+== RELEASE NOTES ==
+
+Raptor Changes
+--------------
+* Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
+SPI Changes
+-----------
+* Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``

--- a/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
@@ -1,0 +1,13 @@
+=============
+Release 0.231
+=============
+
+SPI Changes
+___________
+* Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
+
+Raptor Changes
+______________
+* Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+* Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.
+* Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.

--- a/presto-release-tools/src/test/resources/release-notes-test/release.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release.rst
@@ -1,0 +1,18 @@
+*************
+Release Notes
+*************
+
+.. toctree::
+    :maxdepth: 1
+
+    release/release-0.230
+    release/release-0.229
+    release/release-0.228
+    release/release-0.227
+    release/release-0.226
+    release/release-0.225
+    release/release-0.224
+    release/release-0.223
+    release/release-0.222
+    release/release-0.221
+    release/release-0.220

--- a/presto-release-tools/src/test/resources/release-notes-test/release_expected.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release_expected.rst
@@ -1,0 +1,19 @@
+*************
+Release Notes
+*************
+
+.. toctree::
+    :maxdepth: 1
+
+    release/release-0.231
+    release/release-0.230
+    release/release-0.229
+    release/release-0.228
+    release/release-0.227
+    release/release-0.226
+    release/release-0.225
+    release/release-0.224
+    release/release-0.223
+    release/release-0.222
+    release/release-0.221
+    release/release-0.220


### PR DESCRIPTION
The PR introduces a tool which formalize the release notes collection in the release process.

# Release Notes Collection
To streamline the release process, we introduced a requirement (and PR template) to ask authors to write release notes in the PR description. During the release process, the person doing the release will be able to use this tool to collect and generate the release commit and PR, before polishing it as according to the [Release Notes Guideline](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).

# What does the tool do
1. Switch to master branch. Fast-forward to upstream master.
2. Use `git log` to find the commits introduced in the new release.
3. Use [Github GraphQL API v4](https://developer.github.com/v4/) to fetch the PRs associated with the commits.
4. Parse the PR description, generate release notes, create release branch, modify local files, create release notes commit, and push to origin.
5. Create a release notes PR, with description populated. Release notes PR description contains 3 sections:
  a. A list of PRs with missing release notes, either the PR description do not contain release notes, or the release notes were malformed.
  b. A list of extracted release notes.
  c. A list of all commits introduced in the release.

# How to use the tool
To collect release notes, run the following command after cutting the release branch (bumping the snapshot version on the master branch):
```bash
curl -L -o /tmp/presto_release "https://oss.sonatype.org/service/local/artifact/maven/redirect?g=com.facebook.presto&a=presto-release&v=LATEST&r=snapshots&c=executable&e=jar"
chmod 755 /tmp/presto_release
/tmp/presto_release release-notes --github-user <GITHUB_USER> --github-access-token <GITHUB_ACCESS_TOKEN>
```