### PR TITLE
Support Maven options and version verification

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/ReleaseUtil.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/ReleaseUtil.java
@@ -41,6 +41,15 @@ public class ReleaseUtil
     }
 
     /**
+     * Check if the {@code expectedVersion} matches with the release version.
+     */
+    public static void checkVersion(MavenVersion version, Optional<MavenVersion> expectedVersion)
+    {
+        expectedVersion.ifPresent(expected ->
+                checkState(version.equals(expected), "Version mismatch, expected %s, found %s from pom.xml", expected.getVersion(), version.getVersion()));
+    }
+
+    /**
      * Check for tag validity for the given {@code releaseVersion}.
      */
     public static void checkTags(Git git, MavenVersion releaseVersion)

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepositoryConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepositoryConfig.java
@@ -112,7 +112,7 @@ public class GitRepositoryConfig
     }
 
     @Config("git.upstream-repository")
-    @ConfigDescription("Upstream repository name in the format of <USER/ORGANIZATION>/<REPO>. i.e. prestodb/presto")
+    @ConfigDescription("Repository name for upstream in the format of <USER_OR_ORGANIZATION>/<REPO>, e.g. prestodb/presto.")
     public GitRepositoryConfig setUpstreamRepository(String upstreamRepository)
     {
         this.upstreamRepository = Optional.ofNullable(upstreamRepository);
@@ -126,7 +126,7 @@ public class GitRepositoryConfig
     }
 
     @Config("git.origin-repository")
-    @ConfigDescription("Origin repository name in the format of <USER/ORGANIZATION>/<REPO>. i.e. user/presto")
+    @ConfigDescription("Repository name for origin in the format of <USER_OR_ORGANIZATION>/<REPO>, e.g. user/presto.")
     public GitRepositoryConfig setOriginRepository(String originRepository)
     {
         this.originRepository = Optional.ofNullable(originRepository);

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenCommands.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenCommands.java
@@ -14,31 +14,37 @@
 package com.facebook.presto.release.maven;
 
 import com.facebook.presto.release.AbstractCommands;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.File;
+import java.util.List;
+
+import static java.util.Arrays.asList;
 
 public class MavenCommands
         extends AbstractCommands
         implements Maven
 {
+    private final List<String> options;
+
     public MavenCommands(MavenConfig mavenConfig, File directory)
     {
         super(mavenConfig.getExecutable(), ImmutableMap.of(), directory);
+        this.options = ImmutableList.copyOf(mavenConfig.getOptions());
     }
 
     @Override
     public void setVersions(String version)
     {
-        command("versions:set", "-DnewVersion=" + version);
+        commandWithOptions("versions:set", "-DnewVersion=" + version);
     }
 
     @Override
     public void releasePrepare(String releaseVersion, String developmentVersion, String tag)
     {
-        command(
+        commandWithOptions(
                 "release:prepare",
-                "-T1C",
                 "-DreleaseVersion=" + releaseVersion,
                 "-DdevelopmentVersion=" + developmentVersion,
                 "-Dtag=" + tag);
@@ -47,6 +53,14 @@ public class MavenCommands
     @Override
     public void releaseClean()
     {
-        command("release:clean");
+        commandWithOptions("release:clean");
+    }
+
+    private String commandWithOptions(String... arguments)
+    {
+        return command(ImmutableList.<String>builder()
+                .addAll(options)
+                .addAll(asList(arguments))
+                .build());
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenConfig.java
@@ -14,12 +14,18 @@
 package com.facebook.presto.release.maven;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 
 import javax.validation.constraints.NotNull;
+
+import java.util.List;
 
 public class MavenConfig
 {
     private String executable = "mvn";
+    private List<String> options = ImmutableList.of();
 
     @NotNull
     public String getExecutable()
@@ -31,6 +37,22 @@ public class MavenConfig
     public MavenConfig setExecutable(String executable)
     {
         this.executable = executable;
+        return this;
+    }
+
+    @NotNull
+    public List<String> getOptions()
+    {
+        return options;
+    }
+
+    @Config("maven.options")
+    @ConfigDescription("A comma-separated list of command line options for mvn")
+    public MavenConfig setOptions(String options)
+    {
+        if (options != null) {
+            this.options = ImmutableList.copyOf(Splitter.on(",").splitToList(options));
+        }
         return this;
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersion.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersion.java
@@ -21,10 +21,12 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
@@ -106,5 +108,34 @@ public class MavenVersion
     private String getMinorSuffix()
     {
         return minorVersionNumber.map(version -> "." + version).orElse("");
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("versionNumber", versionNumber)
+                .add("minorVersionNumber", minorVersionNumber)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        MavenVersion o = (MavenVersion) obj;
+        return Objects.equals(versionNumber, o.versionNumber) &&
+                Objects.equals(minorVersionNumber, o.minorVersionNumber);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(versionNumber, minorVersionNumber);
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.release.ReleaseUtil.checkReleaseNotCut;
 import static com.facebook.presto.release.ReleaseUtil.checkTags;
+import static com.facebook.presto.release.ReleaseUtil.checkVersion;
 import static com.facebook.presto.release.ReleaseUtil.getPomFile;
 import static com.facebook.presto.release.ReleaseUtil.sanitizeRepository;
 import static com.facebook.presto.release.git.Git.RemoteType.UPSTREAM;
@@ -39,11 +40,14 @@ public abstract class AbstractCutReleaseTask
     private final GitRepository repository;
     private final Maven maven;
 
-    public AbstractCutReleaseTask(Git git, Maven maven)
+    private final Optional<MavenVersion> expectedVersion;
+
+    public AbstractCutReleaseTask(Git git, Maven maven, VersionVerificationConfig config)
     {
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.maven = requireNonNull(maven, "maven is null");
+        this.expectedVersion = requireNonNull(config.getExpectedVersion(), "expectedVersion is null");
     }
 
     /**
@@ -56,6 +60,7 @@ public abstract class AbstractCutReleaseTask
     {
         sanitizeRepository(git);
         MavenVersion version = MavenVersion.fromDirectory(repository.getDirectory());
+        checkVersion(version, expectedVersion);
         checkTags(git, version);
         checkReleaseNotCut(git, version);
 

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.release.ReleaseUtil.checkReleaseCut;
 import static com.facebook.presto.release.ReleaseUtil.checkTags;
+import static com.facebook.presto.release.ReleaseUtil.checkVersion;
 import static com.facebook.presto.release.ReleaseUtil.getPomFile;
 import static com.facebook.presto.release.ReleaseUtil.getReleaseBranch;
 import static com.facebook.presto.release.ReleaseUtil.sanitizeRepository;
@@ -41,11 +42,14 @@ public abstract class AbstractFinalizeReleaseTask
     private final GitRepository repository;
     private final Maven maven;
 
-    public AbstractFinalizeReleaseTask(Git git, Maven maven)
+    private final Optional<MavenVersion> expectedVersion;
+
+    public AbstractFinalizeReleaseTask(Git git, Maven maven, VersionVerificationConfig config)
     {
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.maven = requireNonNull(maven, "maven is null");
+        this.expectedVersion = requireNonNull(config.getExpectedVersion(), "expectedVersion is null");
     }
 
     protected Git getGit()
@@ -63,6 +67,7 @@ public abstract class AbstractFinalizeReleaseTask
     {
         sanitizeRepository(git);
         MavenVersion version = MavenVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion();
+        checkVersion(version, expectedVersion);
         checkTags(git, version);
         checkReleaseCut(git, version);
 

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseCommand.java
@@ -20,7 +20,8 @@ import com.facebook.presto.release.maven.MavenModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+
+import javax.inject.Inject;
 
 import java.util.List;
 
@@ -28,53 +29,14 @@ import java.util.List;
 public class CutReleaseCommand
         extends AbstractReleaseCommand
 {
-    @Option(name = "--upstream-name", title = "Presto repository upstream name")
-    @ConfigProperty("presto.git.upstream-name")
-    public String gitUpstreamName;
+    @Inject
+    public PrestoRepositoryOptions repositoryOptions = new PrestoRepositoryOptions();
 
-    @Option(name = "--origin-name", title = "Presto repository origin name")
-    @ConfigProperty("presto.git.origin-name")
-    public String gitOriginName;
+    @Inject
+    public GitOptions gitOptions = new GitOptions();
 
-    @Option(name = "--directory", title = "Presto repository directory")
-    @ConfigProperty("presto.git.directory")
-    public String gitDirectory;
-
-    @Option(name = "--check-directory-name", title = "Check whether the git directory name is presto")
-    @ConfigProperty("presto.git.check-directory-name")
-    public String gitCheckDirectoryName;
-
-    @Option(name = "--git-initialize-from-remote", title = "Initialize the local repository from remote")
-    @ConfigProperty("presto.git.initialize-from-remote")
-    public String gitInitializeFromRemote;
-
-    @Option(name = "--upstream-repo", title = "Upstream repository name", description = "Format: <USER/ORGANIZATION>/<REPO>. i.e. prestodb/presto")
-    @ConfigProperty("presto.git.upstream-repository")
-    public String upstreamRepository;
-
-    @Option(name = "--origin-repo", title = "Origin repository name", description = "Format: <USER/ORGANIZATION>/<REPO>. i.e. user/presto")
-    @ConfigProperty("presto.git.origin-repository")
-    public String originRepository;
-
-    @Option(name = "--protocol", title = "Git protocol")
-    @ConfigProperty("presto.git.protocol")
-    public String gitProtocol;
-
-    @Option(name = "--access-token", title = "Github personal access token")
-    @ConfigProperty("presto.git.access-token")
-    public String gitAccessToken;
-
-    @Option(name = "--git-executable", title = "Git executable")
-    @ConfigProperty("git.executable")
-    public String gitExecutable;
-
-    @Option(name = "--git-ssh-key-file", title = "Git SSH key file")
-    @ConfigProperty("git.ssh-key-file")
-    public String gitSshKeyFile;
-
-    @Option(name = "--maven-executable", title = "Maven executable")
-    @ConfigProperty("maven.executable")
-    public String mavenExecutable;
+    @Inject
+    public MavenOptions mavenOptions = new MavenOptions();
 
     @Override
     protected List<Module> getModules()

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseCommand.java
@@ -38,6 +38,9 @@ public class CutReleaseCommand
     @Inject
     public MavenOptions mavenOptions = new MavenOptions();
 
+    @Inject
+    public VersionVerificationOptions versionVerificationOptions = new VersionVerificationOptions();
+
     @Override
     protected List<Module> getModules()
     {

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.release.tasks;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.inject.Scopes.SINGLETON;
 
 public class CutReleaseModule
@@ -24,6 +25,7 @@ public class CutReleaseModule
     @Override
     public void configure(Binder binder)
     {
+        configBinder(binder).bindConfig(VersionVerificationConfig.class);
         binder.bind(CutReleaseTask.class).in(SINGLETON);
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseTask.java
@@ -25,9 +25,9 @@ public class CutReleaseTask
         extends AbstractCutReleaseTask
 {
     @Inject
-    public CutReleaseTask(@ForPresto Git git, @ForPresto Maven maven)
+    public CutReleaseTask(@ForPresto Git git, @ForPresto Maven maven, VersionVerificationConfig config)
     {
-        super(git, maven);
+        super(git, maven, config);
     }
 
     @Override

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseCommand.java
@@ -38,6 +38,9 @@ public class FinalizeReleaseCommand
     @Inject
     public MavenOptions mavenOptions = new MavenOptions();
 
+    @Inject
+    public VersionVerificationOptions versionVerificationOptions = new VersionVerificationOptions();
+
     @Override
     protected List<Module> getModules()
     {

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseCommand.java
@@ -20,7 +20,8 @@ import com.facebook.presto.release.maven.MavenModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+
+import javax.inject.Inject;
 
 import java.util.List;
 
@@ -28,53 +29,14 @@ import java.util.List;
 public class FinalizeReleaseCommand
         extends AbstractReleaseCommand
 {
-    @Option(name = "--upstream-name", title = "Presto repo upstream name")
-    @ConfigProperty("presto.git.upstream-name")
-    public String gitUpstreamName;
+    @Inject
+    public PrestoRepositoryOptions repositoryOptions = new PrestoRepositoryOptions();
 
-    @Option(name = "--origin-name", title = "Presto repo origin name")
-    @ConfigProperty("presto.git.origin-name")
-    public String gitOriginName;
+    @Inject
+    public GitOptions gitOptions = new GitOptions();
 
-    @Option(name = "--directory", title = "Presto repo directory")
-    @ConfigProperty("presto.git.directory")
-    public String gitDirectory;
-
-    @Option(name = "--check-directory-name", title = "Check whether the git directory name is presto")
-    @ConfigProperty("presto.git.check-directory-name")
-    public String gitCheckDirectoryName;
-
-    @Option(name = "--git-initialize-from-remote", title = "Initialize the local repository from remote")
-    @ConfigProperty("presto.git.initialize-from-remote")
-    public String gitInitializeFromRemote;
-
-    @Option(name = "--upstream-repo", title = "Upstream repository name", description = "Format: <USER/ORGANIZATION>/<REPO>. i.e. prestodb/presto")
-    @ConfigProperty("presto.git.upstream-repository")
-    public String upstreamRepository;
-
-    @Option(name = "--origin-repo", title = "Origin repository name", description = "Format: <USER/ORGANIZATION>/<REPO>. i.e. user/presto")
-    @ConfigProperty("presto.git.origin-repository")
-    public String originRepository;
-
-    @Option(name = "--protocol", title = "Git protocol")
-    @ConfigProperty("presto.git.protocol")
-    public String gitProtocol;
-
-    @Option(name = "--access-token", title = "Github personal access token")
-    @ConfigProperty("presto.git.access-token")
-    public String gitAccessToken;
-
-    @Option(name = "--git-executable", title = "Git executable")
-    @ConfigProperty("git.executable")
-    public String gitExecutable;
-
-    @Option(name = "--git-ssh-key-file", title = "Git SSH key file")
-    @ConfigProperty("git.ssh-key-file")
-    public String gitSshKeyFile;
-
-    @Option(name = "--maven-executable", title = "Maven executable")
-    @ConfigProperty("maven.executable")
-    public String mavenExecutable;
+    @Inject
+    public MavenOptions mavenOptions = new MavenOptions();
 
     @Override
     protected List<Module> getModules()

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.release.tasks;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.inject.Scopes.SINGLETON;
 
 public class FinalizeReleaseModule
@@ -24,6 +25,7 @@ public class FinalizeReleaseModule
     @Override
     public void configure(Binder binder)
     {
+        configBinder(binder).bindConfig(VersionVerificationConfig.class);
         binder.bind(FinalizeReleaseTask.class).in(SINGLETON);
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesCommand.java
@@ -22,47 +22,29 @@ import com.google.inject.Module;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 
+import javax.inject.Inject;
+
 import java.util.List;
 
 @Command(name = "release-notes", description = "Presto release notes generator")
 public class GenerateReleaseNotesCommand
         extends AbstractReleaseCommand
 {
-    @Option(name = "--github-user", title = "Github username", required = true)
-    @ConfigProperty("github.user")
-    public String githubUser;
-
-    @Option(name = "--github-access-token", title = "Github Personal Access Token", required = true)
-    @ConfigProperty("github.access-token")
-    public String githubAccessToken;
-
     @Option(name = "--version", title = "Release version")
     @ConfigProperty("release-notes.version")
     public String version;
 
-    @Option(name = "--upstream-name", title = "Presto repo upstream name")
-    @ConfigProperty("presto.git.upstream-name")
-    public String gitUpstreamName;
+    @Inject
+    public PrestoRepositoryOptions repositoryOptions = new PrestoRepositoryOptions();
 
-    @Option(name = "--origin-name", title = "Presto repo origin name")
-    @ConfigProperty("presto.git.origin-name")
-    public String gitOriginName;
+    @Inject
+    public GitOptions gitOptions = new GitOptions();
 
-    @Option(name = "--directory", title = "Presto repo directory")
-    @ConfigProperty("presto.git.directory")
-    public String gitDirectory;
+    @Inject
+    public MavenOptions mavenOptions = new MavenOptions();
 
-    @Option(name = "--check-directory-name", title = "Check whether the git directory name is presto")
-    @ConfigProperty("presto.git.check-directory-name")
-    public String gitCheckDirectoryName;
-
-    @Option(name = "--git-executable", title = "Git executable")
-    @ConfigProperty("git.executable")
-    public String gitExecutable;
-
-    @Option(name = "--git-ssh-key-file", title = "Git SSH key file")
-    @ConfigProperty("git.ssh-key-file")
-    public String gitSshKeyFile;
+    @Inject
+    public GithubOptions githubOptions = new GithubOptions();
 
     @Override
     protected List<Module> getModules()

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GitOptions.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GitOptions.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import io.airlift.airline.Option;
+
+public class GitOptions
+{
+    @Option(name = "--git-executable", title = "executable", description = "Git executable")
+    @ConfigProperty("git.executable")
+    public String executable;
+
+    @Option(name = "--git-ssh-key-file", title = "file", description = "Git SSH key file")
+    @ConfigProperty("git.ssh-key-file")
+    public String sshKeyFile;
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GithubOptions.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GithubOptions.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import io.airlift.airline.Option;
+
+public class GithubOptions
+{
+    @Option(name = "--github-user", title = "user", description = "Github username", required = true)
+    @ConfigProperty("github.user")
+    public String user;
+
+    @Option(name = "--github-access-token", title = "token", description = "Github Personal Access Token", required = true)
+    @ConfigProperty("github.access-token")
+    public String accessToken;
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/MavenOptions.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/MavenOptions.java
@@ -20,4 +20,8 @@ public class MavenOptions
     @Option(name = "--maven-executable", title = "executable", description = "Maven executable")
     @ConfigProperty("maven.executable")
     public String executable;
+
+    @Option(name = "--maven-options", title = "options", description = "Maven options")
+    @ConfigProperty("maven.options")
+    public String options;
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/MavenOptions.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/MavenOptions.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import io.airlift.airline.Option;
+
+public class MavenOptions
+{
+    @Option(name = "--maven-executable", title = "executable", description = "Maven executable")
+    @ConfigProperty("maven.executable")
+    public String executable;
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/PrestoRepositoryOptions.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/PrestoRepositoryOptions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import io.airlift.airline.Option;
+
+public class PrestoRepositoryOptions
+{
+    @Option(name = "--upstream-name", title = "upstream_name", description = "Remote name for upstream repository 'presto'.")
+    @ConfigProperty("presto.git.upstream-name")
+    public String upstreamName;
+
+    @Option(name = "--origin-name", title = "origin_name", description = "Remote name for origin repository 'presto'.")
+    @ConfigProperty("presto.git.origin-name")
+    public String originName;
+
+    @Option(name = "--directory", title = "dir", description = "Directory path for repository 'presto'.")
+    @ConfigProperty("presto.git.directory")
+    public String directory;
+
+    @Option(name = "--check-directory-name", description = "Check whether the git directory name is 'presto'.")
+    @ConfigProperty("presto.git.check-directory-name")
+    public Boolean checkDirectoryName;
+
+    @Option(name = "--git-init-from-remote", description = "Initialize the local repository from remote.")
+    @ConfigProperty("presto.git.initialize-from-remote")
+    public Boolean initializeFromRemote;
+
+    @Option(name = "--upstream-repo", title = "upstream", description = "Repository name for upstream in the format of <USER_OR_ORGANIZATION>/<REPO>, e.g. prestodb/presto.")
+    @ConfigProperty("presto.git.upstream-repository")
+    public String upstreamRepository;
+
+    @Option(name = "--origin-repo", title = "origin", description = "Repository name for origin in the format of <USER_OR_ORGANIZATION>/<REPO>, e.g. user/presto.")
+    @ConfigProperty("presto.git.origin-repository")
+    public String originRepository;
+
+    @Option(name = "--protocol", title = "protocol", description = "Git protocol, either HTTPS or SSH.")
+    @ConfigProperty("presto.git.protocol")
+    public String protocol;
+
+    @Option(name = "--access-token", title = "token", description = "Github personal access token.")
+    @ConfigProperty("presto.git.access-token")
+    public String accessToken;
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/VersionVerificationConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/VersionVerificationConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.release.maven.MavenVersion;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class VersionVerificationConfig
+{
+    private Optional<MavenVersion> expectedVersion = Optional.empty();
+
+    @NotNull
+    public Optional<MavenVersion> getExpectedVersion()
+    {
+        return expectedVersion;
+    }
+
+    @Config("expected-version")
+    public VersionVerificationConfig setExpectedVersion(String expectedVersion)
+    {
+        if (expectedVersion != null) {
+            try {
+                this.expectedVersion = Optional.of(MavenVersion.fromReleaseVersion(expectedVersion));
+            }
+            catch (IllegalArgumentException e) {
+                // ignore
+            }
+        }
+        return this;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/VersionVerificationOptions.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/VersionVerificationOptions.java
@@ -13,25 +13,11 @@
  */
 package com.facebook.presto.release.tasks;
 
-import com.facebook.presto.release.ForPresto;
-import com.facebook.presto.release.git.Git;
-import com.facebook.presto.release.maven.Maven;
-import com.facebook.presto.release.maven.MavenVersion;
-import com.google.inject.Inject;
+import io.airlift.airline.Option;
 
-import java.io.File;
-
-public class FinalizeReleaseTask
-        extends AbstractFinalizeReleaseTask
+public class VersionVerificationOptions
 {
-    @Inject
-    public FinalizeReleaseTask(@ForPresto Git git, @ForPresto Maven maven, VersionVerificationConfig config)
-    {
-        super(git, maven, config);
-    }
-
-    @Override
-    protected void updatePom(File pomFile, MavenVersion releaseVersion)
-    {
-    }
+    @Option(name = "--expected-version", title = "version", description = "Expected release version")
+    @ConfigProperty("expected-version")
+    public String expectedVersion;
 }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/NoOpMaven.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/NoOpMaven.java
@@ -34,7 +34,7 @@ public class NoOpMaven
     @Override
     protected String command(List<String> arguments)
     {
-        commandLogger.log("git", arguments);
+        commandLogger.log("mvn", arguments);
         return "";
     }
 }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestMavenConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestMavenConfig.java
@@ -22,7 +22,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
-public class TestMavenCommands
+public class TestMavenConfig
 {
     @Test
     public void testDefault()

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestMavenConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestMavenConfig.java
@@ -28,7 +28,8 @@ public class TestMavenConfig
     public void testDefault()
     {
         assertRecordedDefaults(recordDefaults(MavenConfig.class)
-                .setExecutable("mvn"));
+                .setExecutable("mvn")
+                .setOptions(null));
     }
 
     @Test
@@ -36,9 +37,11 @@ public class TestMavenConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("maven.executable", "/bin/mvn")
+                .put("maven.options", "-Djava.net.preferIPv6Addresses,--settings=/Users/root/.m2/settings.xml")
                 .build();
         MavenConfig expected = new MavenConfig()
-                .setExecutable("/bin/mvn");
+                .setExecutable("/bin/mvn")
+                .setOptions("-Djava.net.preferIPv6Addresses,--settings=/Users/root/.m2/settings.xml");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCutReleaseTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCutReleaseTask.java
@@ -91,7 +91,7 @@ public class TestCutReleaseTask
                         "git fetch upstream",
                         "git tag",
                         "git ls-remote --heads upstream release-0.232",
-                        "git versions:set -DnewVersion=0.233-SNAPSHOT",
+                        "mvn versions:set -DnewVersion=0.233-SNAPSHOT",
                         "git add .",
                         "git commit -m \"Prepare for next development iteration - 0.233-SNAPSHOT\"",
                         "git push upstream -u master:master",

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
@@ -101,7 +101,7 @@ public class TestFinalizeReleaseTask
                         "git ls-remote --heads upstream release-0.231",
                         "git branch -D release-0.231",
                         "git checkout -b release-0.231 upstream/release-0.231",
-                        "mvn release:prepare -T1C -DreleaseVersion=0.231 -DdevelopmentVersion=0.231.1-SNAPSHOT -Dtag=0.231",
+                        "mvn release:prepare -DreleaseVersion=0.231 -DdevelopmentVersion=0.231.1-SNAPSHOT -Dtag=0.231",
                         "mvn release:clean",
                         "git push upstream -u release-0.231:release-0.231 --tags"));
     }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
@@ -101,8 +101,8 @@ public class TestFinalizeReleaseTask
                         "git ls-remote --heads upstream release-0.231",
                         "git branch -D release-0.231",
                         "git checkout -b release-0.231 upstream/release-0.231",
-                        "git release:prepare -T1C -DreleaseVersion=0.231 -DdevelopmentVersion=0.231.1-SNAPSHOT -Dtag=0.231",
-                        "git release:clean",
+                        "mvn release:prepare -T1C -DreleaseVersion=0.231 -DdevelopmentVersion=0.231.1-SNAPSHOT -Dtag=0.231",
+                        "mvn release:clean",
                         "git push upstream -u release-0.231:release-0.231 --tags"));
     }
 }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestVersionVerificationConfig.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestVersionVerificationConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestVersionVerificationConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(VersionVerificationConfig.class)
+                .setExpectedVersion(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("expected-version", "0.231")
+                .build();
+        VersionVerificationConfig expected = new VersionVerificationConfig()
+                .setExpectedVersion("0.231");
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
- Support Maven options. For example, we'll able to pass in settings file and m2 repo path.
- Support version verification. Release task will abort if specified expected version mismatches extract version from `pom.xml`.
- Improve command line options.
- Small fixes.