### PR TITLE
Sort release notes within each section as according to the guideline

### DIFF
--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
@@ -131,7 +131,7 @@ public class TestGenerateReleaseNotesTask
 
         assertEquals(asCharSource(releaseNotesListFile, UTF_8).read(), getTestResourceContent("release_expected.rst"));
         assertEquals(asCharSource(releaseNotesFile, UTF_8).read(), getTestResourceContent("release-0.231_expected.rst"));
-        assertEquals(githubAction.getCreatedPullRequest().getDescription(), getTestResourceContent("description_expected.txt"));
+        assertEquals(githubAction.getCreatedPullRequest().getDescription().trim(), getTestResourceContent("description_expected.txt").trim());
     }
 
     private GenerateReleaseNotesTask initializeTask(List<Commit> commits)

--- a/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
@@ -13,9 +13,13 @@
 
 # Extracted Release Notes
 - #1 (Author: user1): release notes 1
-  - Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
-  - Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.
+  - Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+  - Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
+  - Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
+  - Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.
 - #2 (Author: user2): release notes 2
+  - Improve correctness check for RowType columns. Add specific validation checks for the individual fields when validating a row column.
+  - Remove unused FilterVoidLambda interface in ArrayFilterFunction.
   - Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
   - Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
 

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
@@ -1,5 +1,7 @@
 == RELEASE NOTES ==
 
 Raptor Changes
-* Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
-* Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.
+* Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+* Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
+* Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
+* Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
@@ -2,6 +2,9 @@
 
 Raptor Changes
 --------------
+* Improve correctness check for RowType columns.
+  Add specific validation checks for the individual fields when validating a row column.
+* Remove unused FilterVoidLambda interface in ArrayFilterFunction
 * Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
 SPI Changes
 -----------

--- a/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
@@ -8,6 +8,10 @@ ___________
 
 Raptor Changes
 ______________
-* Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
-* Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.
+* Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
+* Improve correctness check for RowType columns. Add specific validation checks for the individual fields when validating a row column.
 * Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
+* Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.
+* Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
+* Remove unused FilterVoidLambda interface in ArrayFilterFunction.
+* Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.


### PR DESCRIPTION
According to [Release Notes Guideline](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines#order-of-changes), order by changes should be:
```
Fixes: line starts with Fix ...
Optimizations: line starts with Improve ...
Additions: line starts with Add...
Replacements: line starts with Replace...
Renames: line starts with Rename...
Deletions: line starts with Remove...
```

I added `Replacements` and `Renames` as we're seeing more of those use cases in recent release notes.

Sort release notes by the type of change first, then alphabetically within each change type. Release notes not in any of those change types are placed at the last.