### PR TITLE
Support non-Presto Maven version for release finalize

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/ReleaseUtil.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/ReleaseUtil.java
@@ -79,16 +79,16 @@ public class ReleaseUtil
 
     public static void checkReleaseCut(Git git, MavenVersion version)
     {
-        checkState(!git.listUpstreamHeads(getReleaseBranch(version)).isEmpty(), "Release %s has not been cut", version.getVersion());
+        checkState(!git.listUpstreamHeads(getReleaseBranch(version)).isEmpty(), "Release %s has not been cut", version.getMajorVersion());
     }
 
     public static void checkReleaseNotCut(Git git, MavenVersion version)
     {
-        checkState(git.listUpstreamHeads(getReleaseBranch(version)).isEmpty(), "Release %s is already cut", version.getVersion());
+        checkState(git.listUpstreamHeads(getReleaseBranch(version)).isEmpty(), "Release %s is already cut", version.getMajorVersion());
     }
 
     public static String getReleaseBranch(MavenVersion version)
     {
-        return RELEASE_BRANCH_PREFIX + version.getVersion();
+        return RELEASE_BRANCH_PREFIX + version.getMajorVersion();
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersion.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersion.java
@@ -13,141 +13,24 @@
  */
 package com.facebook.presto.release.maven;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Paths;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Integer.parseInt;
-import static java.lang.String.format;
-
-public class MavenVersion
+public interface MavenVersion
 {
-    private static final Pattern RELEASE_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?");
-    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?-SNAPSHOT");
+    boolean isHotFixVersion();
 
-    private final int versionNumber;
-    private final Optional<Integer> minorVersionNumber;
+    MavenVersion getMajorVersion();
 
-    private MavenVersion(int versionNumber, Optional<Integer> minorVersionNumber)
+    MavenVersion getLastMajorVersion();
+
+    MavenVersion getNextMajorVersion();
+
+    MavenVersion getLastMinorVersion();
+
+    MavenVersion getNextMinorVersion();
+
+    String getVersion();
+
+    default String getSnapshotVersion()
     {
-        checkArgument(versionNumber > 0, "Expect positive version number, found: %s", versionNumber);
-        checkArgument(!minorVersionNumber.isPresent() || minorVersionNumber.get() > 0, "Expect positive minor version number, found: %s", minorVersionNumber.orElse(null));
-        this.versionNumber = versionNumber;
-        this.minorVersionNumber = minorVersionNumber;
-    }
-
-    public static MavenVersion fromDirectory(File directory)
-    {
-        checkArgument(directory.exists(), "Does not exists: %s", directory.getAbsolutePath());
-        checkArgument(directory.isDirectory(), "Not a directory: %s", directory.getAbsolutePath());
-        return fromPom(Paths.get(directory.getAbsolutePath(), "pom.xml").toFile());
-    }
-
-    public static MavenVersion fromPom(File file)
-    {
-        try {
-            Map<String, Object> elements = new XmlMapper().readValue(file, new TypeReference<Map<String, Object>>() {});
-            checkArgument(elements.containsKey("version"), "No version tag found in %s", file.getAbsolutePath());
-            return fromSnapshotVersion((String) elements.get("version"));
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    public static MavenVersion fromReleaseVersion(String version)
-    {
-        Matcher matcher = RELEASE_VERSION_PATTERN.matcher(version);
-        checkArgument(matcher.matches(), "Invalid release version: %s", version);
-        return new MavenVersion(parseInt(matcher.group(1)), Optional.ofNullable(matcher.group(3)).map(Integer::parseInt));
-    }
-
-    public static MavenVersion fromSnapshotVersion(String version)
-    {
-        Matcher matcher = SNAPSHOT_VERSION_PATTERN.matcher(version);
-        checkArgument(matcher.matches(), "Invalid snapshot version: %s", version);
-        return new MavenVersion(parseInt(matcher.group(1)), Optional.ofNullable(matcher.group(3)).map(Integer::parseInt));
-    }
-
-    public boolean isHotFixVersion()
-    {
-        return minorVersionNumber.isPresent();
-    }
-
-    public MavenVersion getMajorVersion()
-    {
-        return new MavenVersion(versionNumber, Optional.empty());
-    }
-
-    public MavenVersion getLastMajorVersion()
-    {
-        return new MavenVersion(versionNumber - 1, Optional.empty());
-    }
-
-    public MavenVersion getNextMajorVersion()
-    {
-        return new MavenVersion(versionNumber + 1, Optional.empty());
-    }
-
-    public MavenVersion getLastMinorVersion()
-    {
-        checkArgument(minorVersionNumber.isPresent(), format("No last minor version for major version: %s", toString()));
-        return new MavenVersion(versionNumber, minorVersionNumber.get() == 1 ? Optional.empty() : Optional.of(minorVersionNumber.get() - 1));
-    }
-
-    public MavenVersion getNextMinorVersion()
-    {
-        return new MavenVersion(versionNumber, Optional.of(minorVersionNumber.orElse(0) + 1));
-    }
-
-    public String getVersion()
-    {
-        return format("0.%s%s", versionNumber, getMinorSuffix());
-    }
-
-    public String getSnapshotVersion()
-    {
-        return format("0.%s%s-SNAPSHOT", versionNumber, getMinorSuffix());
-    }
-
-    private String getMinorSuffix()
-    {
-        return minorVersionNumber.map(version -> "." + version).orElse("");
-    }
-
-    @Override
-    public String toString()
-    {
-        return getVersion();
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (this == obj) {
-            return true;
-        }
-        if ((obj == null) || (getClass() != obj.getClass())) {
-            return false;
-        }
-        MavenVersion o = (MavenVersion) obj;
-        return Objects.equals(versionNumber, o.versionNumber) &&
-                Objects.equals(minorVersionNumber, o.minorVersionNumber);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(versionNumber, minorVersionNumber);
+        return getVersion() + "-SNAPSHOT";
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersionFactory.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersionFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.maven;
+
+public interface MavenVersionFactory<T extends MavenVersion>
+{
+    T create(String version);
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersionUtil.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/MavenVersionUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.maven;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class MavenVersionUtil
+{
+    private MavenVersionUtil()
+    {
+    }
+
+    public static String getVersionFromPom(File directory)
+    {
+        checkArgument(directory.exists(), "Does not exists: %s", directory.getAbsolutePath());
+        checkArgument(directory.isDirectory(), "Not a directory: %s", directory.getAbsolutePath());
+        File pomFile = Paths.get(directory.getAbsolutePath(), "pom.xml").toFile();
+        try {
+            Map<String, Object> elements = new XmlMapper().readValue(pomFile, new TypeReference<Map<String, Object>>() {});
+            checkArgument(elements.containsKey("version"), "No version tag found in %s", pomFile.getAbsolutePath());
+            return (String) elements.get("version");
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/PrestoVersion.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/PrestoVersion.java
@@ -13,14 +13,6 @@
  */
 package com.facebook.presto.release.maven;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Paths;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -33,13 +25,12 @@ import static java.lang.String.format;
 public class PrestoVersion
         implements MavenVersion
 {
-    private static final Pattern RELEASE_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?");
-    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?-SNAPSHOT");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?(-SNAPSHOT)?");
 
     private final int versionNumber;
     private final Optional<Integer> minorVersionNumber;
 
-    private PrestoVersion(int versionNumber, Optional<Integer> minorVersionNumber)
+    protected PrestoVersion(int versionNumber, Optional<Integer> minorVersionNumber)
     {
         checkArgument(versionNumber > 0, "Expect positive version number, found: %s", versionNumber);
         checkArgument(!minorVersionNumber.isPresent() || minorVersionNumber.get() > 0, "Expect positive minor version number, found: %s", minorVersionNumber.orElse(null));
@@ -47,36 +38,10 @@ public class PrestoVersion
         this.minorVersionNumber = minorVersionNumber;
     }
 
-    public static PrestoVersion fromDirectory(File directory)
+    public static PrestoVersion create(String version)
     {
-        checkArgument(directory.exists(), "Does not exists: %s", directory.getAbsolutePath());
-        checkArgument(directory.isDirectory(), "Not a directory: %s", directory.getAbsolutePath());
-        return fromPom(Paths.get(directory.getAbsolutePath(), "pom.xml").toFile());
-    }
-
-    public static PrestoVersion fromPom(File file)
-    {
-        try {
-            Map<String, Object> elements = new XmlMapper().readValue(file, new TypeReference<Map<String, Object>>() {});
-            checkArgument(elements.containsKey("version"), "No version tag found in %s", file.getAbsolutePath());
-            return fromSnapshotVersion((String) elements.get("version"));
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    public static PrestoVersion fromReleaseVersion(String version)
-    {
-        Matcher matcher = RELEASE_VERSION_PATTERN.matcher(version);
-        checkArgument(matcher.matches(), "Invalid release version: %s", version);
-        return new PrestoVersion(parseInt(matcher.group(1)), Optional.ofNullable(matcher.group(3)).map(Integer::parseInt));
-    }
-
-    public static PrestoVersion fromSnapshotVersion(String version)
-    {
-        Matcher matcher = SNAPSHOT_VERSION_PATTERN.matcher(version);
-        checkArgument(matcher.matches(), "Invalid snapshot version: %s", version);
+        Matcher matcher = VERSION_PATTERN.matcher(version);
+        checkArgument(matcher.matches(), "Invalid version: %s", version);
         return new PrestoVersion(parseInt(matcher.group(1)), Optional.ofNullable(matcher.group(3)).map(Integer::parseInt));
     }
 

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/maven/PrestoVersion.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/maven/PrestoVersion.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.maven;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
+
+public class PrestoVersion
+        implements MavenVersion
+{
+    private static final Pattern RELEASE_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?");
+    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("0\\.([1-9][0-9]*)(\\.([1-9][0-9]*))?-SNAPSHOT");
+
+    private final int versionNumber;
+    private final Optional<Integer> minorVersionNumber;
+
+    private PrestoVersion(int versionNumber, Optional<Integer> minorVersionNumber)
+    {
+        checkArgument(versionNumber > 0, "Expect positive version number, found: %s", versionNumber);
+        checkArgument(!minorVersionNumber.isPresent() || minorVersionNumber.get() > 0, "Expect positive minor version number, found: %s", minorVersionNumber.orElse(null));
+        this.versionNumber = versionNumber;
+        this.minorVersionNumber = minorVersionNumber;
+    }
+
+    public static PrestoVersion fromDirectory(File directory)
+    {
+        checkArgument(directory.exists(), "Does not exists: %s", directory.getAbsolutePath());
+        checkArgument(directory.isDirectory(), "Not a directory: %s", directory.getAbsolutePath());
+        return fromPom(Paths.get(directory.getAbsolutePath(), "pom.xml").toFile());
+    }
+
+    public static PrestoVersion fromPom(File file)
+    {
+        try {
+            Map<String, Object> elements = new XmlMapper().readValue(file, new TypeReference<Map<String, Object>>() {});
+            checkArgument(elements.containsKey("version"), "No version tag found in %s", file.getAbsolutePath());
+            return fromSnapshotVersion((String) elements.get("version"));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static PrestoVersion fromReleaseVersion(String version)
+    {
+        Matcher matcher = RELEASE_VERSION_PATTERN.matcher(version);
+        checkArgument(matcher.matches(), "Invalid release version: %s", version);
+        return new PrestoVersion(parseInt(matcher.group(1)), Optional.ofNullable(matcher.group(3)).map(Integer::parseInt));
+    }
+
+    public static PrestoVersion fromSnapshotVersion(String version)
+    {
+        Matcher matcher = SNAPSHOT_VERSION_PATTERN.matcher(version);
+        checkArgument(matcher.matches(), "Invalid snapshot version: %s", version);
+        return new PrestoVersion(parseInt(matcher.group(1)), Optional.ofNullable(matcher.group(3)).map(Integer::parseInt));
+    }
+
+    @Override
+    public boolean isHotFixVersion()
+    {
+        return minorVersionNumber.isPresent();
+    }
+
+    @Override
+    public MavenVersion getMajorVersion()
+    {
+        return new PrestoVersion(versionNumber, Optional.empty());
+    }
+
+    @Override
+    public MavenVersion getLastMajorVersion()
+    {
+        return new PrestoVersion(versionNumber - 1, Optional.empty());
+    }
+
+    @Override
+    public MavenVersion getNextMajorVersion()
+    {
+        return new PrestoVersion(versionNumber + 1, Optional.empty());
+    }
+
+    @Override
+    public MavenVersion getLastMinorVersion()
+    {
+        checkArgument(minorVersionNumber.isPresent(), format("No last minor version for major version: %s", toString()));
+        return new PrestoVersion(versionNumber, minorVersionNumber.get() == 1 ? Optional.empty() : Optional.of(minorVersionNumber.get() - 1));
+    }
+
+    @Override
+    public MavenVersion getNextMinorVersion()
+    {
+        return new PrestoVersion(versionNumber, Optional.of(minorVersionNumber.orElse(0) + 1));
+    }
+
+    @Override
+    public String getVersion()
+    {
+        return format("0.%s%s", versionNumber, minorVersionNumber.map(version -> "." + version).orElse(""));
+    }
+
+    @Override
+    public String toString()
+    {
+        return getVersion();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        PrestoVersion o = (PrestoVersion) obj;
+        return Objects.equals(versionNumber, o.versionNumber) &&
+                Objects.equals(minorVersionNumber, o.minorVersionNumber);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(versionNumber, minorVersionNumber);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
@@ -55,13 +55,13 @@ public abstract class AbstractCutReleaseTask
     /**
      * Perform a custom update to the pom file.
      */
-    protected abstract void updatePom(File pomFile, MavenVersion releaseVersion);
+    protected abstract void updatePom(File pomFile, PrestoVersion releaseVersion);
 
     @Override
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion version = PrestoVersion.create(getVersionFromPom(repository.getDirectory()));
+        PrestoVersion version = PrestoVersion.create(getVersionFromPom(repository.getDirectory()));
         releaseVersion.ifPresent(mavenVersion -> checkVersion(mavenVersion, version));
         checkTags(git, version);
         checkReleaseNotCut(git, version);

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
@@ -18,6 +18,7 @@ import com.facebook.presto.release.git.Git;
 import com.facebook.presto.release.git.GitRepository;
 import com.facebook.presto.release.maven.Maven;
 import com.facebook.presto.release.maven.MavenVersion;
+import com.facebook.presto.release.maven.PrestoVersion;
 
 import java.io.File;
 import java.util.Optional;
@@ -47,7 +48,7 @@ public abstract class AbstractCutReleaseTask
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.maven = requireNonNull(maven, "maven is null");
-        this.releaseVersion = requireNonNull(config.getReleaseVersion(), "releaseVersion is null");
+        this.releaseVersion = config.getReleaseVersion().map(PrestoVersion::fromReleaseVersion);
     }
 
     /**
@@ -59,7 +60,7 @@ public abstract class AbstractCutReleaseTask
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion version = MavenVersion.fromDirectory(repository.getDirectory());
+        MavenVersion version = PrestoVersion.fromDirectory(repository.getDirectory());
         releaseVersion.ifPresent(mavenVersion -> checkVersion(mavenVersion, version));
         checkTags(git, version);
         checkReleaseNotCut(git, version);

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractCutReleaseTask.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.release.ReleaseUtil.checkVersion;
 import static com.facebook.presto.release.ReleaseUtil.getPomFile;
 import static com.facebook.presto.release.ReleaseUtil.sanitizeRepository;
 import static com.facebook.presto.release.git.Git.RemoteType.UPSTREAM;
+import static com.facebook.presto.release.maven.MavenVersionUtil.getVersionFromPom;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +49,7 @@ public abstract class AbstractCutReleaseTask
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.maven = requireNonNull(maven, "maven is null");
-        this.releaseVersion = config.getReleaseVersion().map(PrestoVersion::fromReleaseVersion);
+        this.releaseVersion = config.getReleaseVersion().map(PrestoVersion::create);
     }
 
     /**
@@ -60,7 +61,7 @@ public abstract class AbstractCutReleaseTask
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion version = PrestoVersion.fromDirectory(repository.getDirectory());
+        MavenVersion version = PrestoVersion.create(getVersionFromPom(repository.getDirectory()));
         releaseVersion.ifPresent(mavenVersion -> checkVersion(mavenVersion, version));
         checkTags(git, version);
         checkReleaseNotCut(git, version);

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
@@ -77,11 +77,10 @@ public abstract class AbstractFinalizeReleaseTask
             checkVersion(releaseVersion.get(), masterReleaseVersion);
         }
         MavenVersion version = releaseVersion.orElse(masterReleaseVersion);
-        MavenVersion majorVersion = version.getMajorVersion();
         checkTags(git, version);
-        checkReleaseCut(git, majorVersion);
+        checkReleaseCut(git, version);
 
-        String releaseBranch = getReleaseBranch(majorVersion);
+        String releaseBranch = getReleaseBranch(version);
         try {
             git.deleteBranch(releaseBranch);
         }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
@@ -19,6 +19,7 @@ import com.facebook.presto.release.git.Git;
 import com.facebook.presto.release.git.GitRepository;
 import com.facebook.presto.release.maven.Maven;
 import com.facebook.presto.release.maven.MavenVersion;
+import com.facebook.presto.release.maven.PrestoVersion;
 
 import java.io.File;
 import java.util.Optional;
@@ -49,7 +50,7 @@ public abstract class AbstractFinalizeReleaseTask
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.maven = requireNonNull(maven, "maven is null");
-        this.releaseVersion = requireNonNull(config.getReleaseVersion(), "releaseVersion is null");
+        this.releaseVersion = config.getReleaseVersion().map(PrestoVersion::fromReleaseVersion);
     }
 
     protected Git getGit()
@@ -71,7 +72,7 @@ public abstract class AbstractFinalizeReleaseTask
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion masterReleaseVersion = MavenVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion();
+        MavenVersion masterReleaseVersion = PrestoVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion();
         if (releaseVersion.isPresent() && !releaseVersion.get().isHotFixVersion()) {
             checkVersion(releaseVersion.get(), masterReleaseVersion);
         }
@@ -89,7 +90,7 @@ public abstract class AbstractFinalizeReleaseTask
         }
         git.checkout(Optional.of(format("%s/%s", repository.getUpstreamName(), releaseBranch)), Optional.of(releaseBranch));
         if (version.isHotFixVersion()) {
-            MavenVersion branchReleaseVersion = MavenVersion.fromDirectory(repository.getDirectory());
+            MavenVersion branchReleaseVersion = PrestoVersion.fromDirectory(repository.getDirectory());
             checkVersion(version, branchReleaseVersion);
         }
 

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/AbstractFinalizeReleaseTask.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.release.ReleaseUtil.getPomFile;
 import static com.facebook.presto.release.ReleaseUtil.getReleaseBranch;
 import static com.facebook.presto.release.ReleaseUtil.sanitizeRepository;
 import static com.facebook.presto.release.git.Git.RemoteType.UPSTREAM;
+import static com.facebook.presto.release.maven.MavenVersionUtil.getVersionFromPom;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -50,7 +51,7 @@ public abstract class AbstractFinalizeReleaseTask
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.maven = requireNonNull(maven, "maven is null");
-        this.releaseVersion = config.getReleaseVersion().map(PrestoVersion::fromReleaseVersion);
+        this.releaseVersion = config.getReleaseVersion().map(PrestoVersion::create);
     }
 
     protected Git getGit()
@@ -72,7 +73,7 @@ public abstract class AbstractFinalizeReleaseTask
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion masterReleaseVersion = PrestoVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion();
+        MavenVersion masterReleaseVersion = PrestoVersion.create(getVersionFromPom(repository.getDirectory())).getLastMajorVersion();
         if (releaseVersion.isPresent() && !releaseVersion.get().isHotFixVersion()) {
             checkVersion(releaseVersion.get(), masterReleaseVersion);
         }
@@ -89,7 +90,7 @@ public abstract class AbstractFinalizeReleaseTask
         }
         git.checkout(Optional.of(format("%s/%s", repository.getUpstreamName(), releaseBranch)), Optional.of(releaseBranch));
         if (version.isHotFixVersion()) {
-            MavenVersion branchReleaseVersion = PrestoVersion.fromDirectory(repository.getDirectory());
+            MavenVersion branchReleaseVersion = PrestoVersion.create(getVersionFromPom(repository.getDirectory()));
             checkVersion(version, branchReleaseVersion);
         }
 

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CutReleaseTask.java
@@ -16,7 +16,7 @@ package com.facebook.presto.release.tasks;
 import com.facebook.presto.release.ForPresto;
 import com.facebook.presto.release.git.Git;
 import com.facebook.presto.release.maven.Maven;
-import com.facebook.presto.release.maven.MavenVersion;
+import com.facebook.presto.release.maven.PrestoVersion;
 import com.google.inject.Inject;
 
 import java.io.File;
@@ -31,7 +31,7 @@ public class CutReleaseTask
     }
 
     @Override
-    protected void updatePom(File pomFile, MavenVersion releaseVersion)
+    protected void updatePom(File pomFile, PrestoVersion releaseVersion)
     {
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/FinalizeReleaseTask.java
@@ -16,27 +16,27 @@ package com.facebook.presto.release.tasks;
 import com.facebook.presto.release.ForPresto;
 import com.facebook.presto.release.git.Git;
 import com.facebook.presto.release.maven.Maven;
-import com.facebook.presto.release.maven.MavenVersion;
+import com.facebook.presto.release.maven.PrestoVersion;
 import com.google.inject.Inject;
 
 import java.io.File;
 
 public class FinalizeReleaseTask
-        extends AbstractFinalizeReleaseTask
+        extends AbstractFinalizeReleaseTask<PrestoVersion>
 {
     @Inject
     public FinalizeReleaseTask(@ForPresto Git git, @ForPresto Maven maven, VersionConfig config)
     {
-        super(git, maven, config);
+        super(git, maven, PrestoVersion::create, config);
     }
 
     @Override
-    protected void updatePomBeforeReleasePrepare(File pomFile, MavenVersion releaseVersion)
+    protected void updatePomBeforeReleasePrepare(File pomFile, PrestoVersion releaseVersion)
     {
     }
 
     @Override
-    protected void updatePomAfterReleasePrepare(File pomFile, MavenVersion releaseVersion)
+    protected void updatePomAfterReleasePrepare(File pomFile, PrestoVersion releaseVersion)
     {
     }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -50,6 +50,7 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.release.ReleaseUtil.sanitizeRepository;
 import static com.facebook.presto.release.git.Git.RemoteType.ORIGIN;
+import static com.facebook.presto.release.maven.MavenVersionUtil.getVersionFromPom;
 import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ExtractionStatus.EXPECT_DASHES_OR_RELEASE_NOTE;
 import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ExtractionStatus.EXPECT_LINE;
 import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ExtractionStatus.EXPECT_SECTION_HEADER;
@@ -101,14 +102,14 @@ public class GenerateReleaseNotesTask
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.githubAction = requireNonNull(githubAction, "githubAction is null");
-        this.version = config.getVersion().map(PrestoVersion::fromReleaseVersion);
+        this.version = config.getVersion().map(PrestoVersion::create);
     }
 
     @Override
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion version = this.version.orElseGet(() -> PrestoVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion());
+        MavenVersion version = this.version.orElseGet(() -> PrestoVersion.create(getVersionFromPom(repository.getDirectory())).getLastMajorVersion());
 
         log.info("Release version: %s, Last Version: %s", version.getVersion(), version.getLastMajorVersion().getVersion());
         List<String> commitIds = Splitter.on("\n")

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -21,6 +21,7 @@ import com.facebook.presto.release.git.GitRepository;
 import com.facebook.presto.release.git.GithubAction;
 import com.facebook.presto.release.git.PullRequest;
 import com.facebook.presto.release.maven.MavenVersion;
+import com.facebook.presto.release.maven.PrestoVersion;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -100,14 +101,14 @@ public class GenerateReleaseNotesTask
         this.git = requireNonNull(git, "git is null");
         this.repository = requireNonNull(git.getRepository(), "repository is null");
         this.githubAction = requireNonNull(githubAction, "githubAction is null");
-        this.version = config.getVersion().map(MavenVersion::fromReleaseVersion);
+        this.version = config.getVersion().map(PrestoVersion::fromReleaseVersion);
     }
 
     @Override
     public void run()
     {
         sanitizeRepository(git);
-        MavenVersion version = this.version.orElseGet(() -> MavenVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion());
+        MavenVersion version = this.version.orElseGet(() -> PrestoVersion.fromDirectory(repository.getDirectory()).getLastMajorVersion());
 
         log.info("Release version: %s, Last Version: %s", version.getVersion(), version.getLastMajorVersion().getVersion());
         List<String> commitIds = Splitter.on("\n")

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/VersionConfig.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/VersionConfig.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.release.tasks;
 
 import com.facebook.airlift.configuration.Config;
-import com.facebook.presto.release.maven.MavenVersion;
 
 import javax.validation.constraints.NotNull;
 
@@ -22,10 +21,10 @@ import java.util.Optional;
 
 public class VersionConfig
 {
-    private Optional<MavenVersion> releaseVersion = Optional.empty();
+    private Optional<String> releaseVersion = Optional.empty();
 
     @NotNull
-    public Optional<MavenVersion> getReleaseVersion()
+    public Optional<String> getReleaseVersion()
     {
         return releaseVersion;
     }
@@ -33,14 +32,7 @@ public class VersionConfig
     @Config("release-version")
     public VersionConfig setReleaseVersion(String releaseVersion)
     {
-        if (releaseVersion != null) {
-            try {
-                this.releaseVersion = Optional.of(MavenVersion.fromReleaseVersion(releaseVersion));
-            }
-            catch (IllegalArgumentException e) {
-                // ignore
-            }
-        }
+        this.releaseVersion = Optional.ofNullable(releaseVersion);
         return this;
     }
 }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/AbstractMavenVersionTest.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/AbstractMavenVersionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.maven;
+
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public abstract class AbstractMavenVersionTest
+{
+    private final MavenVersionFactory<?> versionFactory;
+
+    public AbstractMavenVersionTest(MavenVersionFactory<?> versionFactory)
+    {
+        this.versionFactory = requireNonNull(versionFactory, "versionFactory is null");
+    }
+
+    protected void assertVersion(String version)
+    {
+        String snapshotVersion = version + "-SNAPSHOT";
+
+        assertEquals(versionFactory.create(version).getVersion(), version);
+        assertEquals(versionFactory.create(snapshotVersion).getVersion(), version);
+        assertEquals(versionFactory.create(version).getSnapshotVersion(), snapshotVersion);
+        assertEquals(versionFactory.create(snapshotVersion).getSnapshotVersion(), snapshotVersion);
+    }
+
+    protected static void assertFailed(Runnable runnable, String errorMessageRegexp)
+    {
+        try {
+            runnable.run();
+            fail("Expect exception but succeeded");
+        }
+        catch (RuntimeException e) {
+            assertTrue(
+                    Pattern.compile(errorMessageRegexp).matcher(e.getMessage()).matches(),
+                    format("Error message '%s' does not match expected pattern '%s'",
+                            e.getMessage(),
+                            errorMessageRegexp));
+        }
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestPrestoVersion.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestPrestoVersion.java
@@ -18,17 +18,17 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.regex.Pattern;
 
-import static com.facebook.presto.release.maven.MavenVersion.fromDirectory;
-import static com.facebook.presto.release.maven.MavenVersion.fromPom;
-import static com.facebook.presto.release.maven.MavenVersion.fromReleaseVersion;
-import static com.facebook.presto.release.maven.MavenVersion.fromSnapshotVersion;
+import static com.facebook.presto.release.maven.PrestoVersion.fromDirectory;
+import static com.facebook.presto.release.maven.PrestoVersion.fromPom;
+import static com.facebook.presto.release.maven.PrestoVersion.fromReleaseVersion;
+import static com.facebook.presto.release.maven.PrestoVersion.fromSnapshotVersion;
 import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TestMavenVersion
+public class TestPrestoVersion
 {
     @Test
     public void testReleaseVersion()

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestPrestoVersion.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/maven/TestPrestoVersion.java
@@ -16,71 +16,49 @@ package com.facebook.presto.release.maven;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.regex.Pattern;
 
-import static com.facebook.presto.release.maven.PrestoVersion.fromDirectory;
-import static com.facebook.presto.release.maven.PrestoVersion.fromPom;
-import static com.facebook.presto.release.maven.PrestoVersion.fromReleaseVersion;
-import static com.facebook.presto.release.maven.PrestoVersion.fromSnapshotVersion;
+import static com.facebook.presto.release.maven.MavenVersionUtil.getVersionFromPom;
 import static com.google.common.io.Resources.getResource;
-import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 public class TestPrestoVersion
+        extends AbstractMavenVersionTest
 {
-    @Test
-    public void testReleaseVersion()
+    public TestPrestoVersion()
     {
-        assertEquals(fromReleaseVersion("0.230").getVersion(), "0.230");
-        assertEquals(fromReleaseVersion("0.230.1").getVersion(), "0.230.1");
-        assertEquals(fromReleaseVersion("0.230.2").getVersion(), "0.230.2");
+        super(PrestoVersion::create);
     }
 
     @Test
-    public void testInvalidReleaseVersion()
+    public void testVersion()
     {
-        assertFailed(() -> fromReleaseVersion("0.230-SNAPSHOT"), "Invalid release version: 0\\.230-SNAPSHOT");
-        assertFailed(() -> fromReleaseVersion("0.230.0"), "Invalid release version: 0\\.230\\.0");
-        assertFailed(() -> fromReleaseVersion("230"), "Invalid release version: 230");
-        assertFailed(() -> fromReleaseVersion("0.0"), "Invalid release version: 0.0");
+        assertVersion("0.230");
+        assertVersion("0.230.1");
+        assertVersion("0.230.2");
     }
 
     @Test
-    public void testSnapshotVersion()
+    public void testInvalidVersion()
     {
-        assertEquals(fromSnapshotVersion("0.230-SNAPSHOT").getVersion(), "0.230");
-        assertEquals(fromSnapshotVersion("0.230.1-SNAPSHOT").getVersion(), "0.230.1");
-        assertEquals(fromSnapshotVersion("0.230.2-SNAPSHOT").getVersion(), "0.230.2");
-    }
+        assertFailed(() -> PrestoVersion.create("0.230.0"), "Invalid version: 0\\.230\\.0");
+        assertFailed(() -> PrestoVersion.create("230"), "Invalid version: 230");
+        assertFailed(() -> PrestoVersion.create("0.0"), "Invalid version: 0.0");
 
-    @Test
-    public void testInvalidSnapshotVersion()
-    {
-        assertFailed(() -> fromSnapshotVersion("0.230"), "Invalid snapshot version: 0\\.230");
-        assertFailed(() -> fromSnapshotVersion("0.230.0-SNAPSHOT"), "Invalid snapshot version: 0\\.230\\.0-SNAPSHOT");
-        assertFailed(() -> fromSnapshotVersion("230-SNAPSHOT"), "Invalid snapshot version: 230-SNAPSHOT");
-    }
-
-    @Test
-    public void testFromPom()
-    {
-        File pomFile = new File(getResource("pom.xml").getFile());
-        assertEquals(fromPom(pomFile).getVersion(), "0.232");
+        assertFailed(() -> PrestoVersion.create("0.230.0-SNAPSHOT"), "Invalid version: 0\\.230\\.0-SNAPSHOT");
+        assertFailed(() -> PrestoVersion.create("230-SNAPSHOT"), "Invalid version: 230-SNAPSHOT");
     }
 
     @Test
     public void testFromDirectory()
     {
-        File pomFile = new File(getResource("pom.xml").getFile()).getParentFile();
-        assertEquals(fromDirectory(pomFile).getVersion(), "0.232");
+        File directory = new File(getResource("pom.xml").getFile()).getParentFile();
+        assertEquals(PrestoVersion.create(getVersionFromPom(directory)).getVersion(), "0.232");
     }
 
     @Test
     public void testVersionChange()
     {
-        MavenVersion version = fromReleaseVersion("0.230");
+        MavenVersion version = PrestoVersion.create("0.230");
 
         MavenVersion lastMajor = version.getLastMajorVersion();
         assertEquals(lastMajor.getVersion(), "0.229");
@@ -98,20 +76,5 @@ public class TestPrestoVersion
         assertEquals(nextMinor.getNextMajorVersion().getSnapshotVersion(), "0.231-SNAPSHOT");
         assertEquals(nextMinor.getNextMinorVersion().getVersion(), "0.230.2");
         assertEquals(nextMinor.getNextMinorVersion().getSnapshotVersion(), "0.230.2-SNAPSHOT");
-    }
-
-    private static void assertFailed(Runnable runnable, String errorMessageRegexp)
-    {
-        try {
-            runnable.run();
-            fail("Expect exception but succeeded");
-        }
-        catch (RuntimeException e) {
-            assertTrue(
-                    Pattern.compile(errorMessageRegexp).matcher(e.getMessage()).matches(),
-                    format("Error message '%s' does not match expected pattern '%s'",
-                            e.getMessage(),
-                            errorMessageRegexp));
-        }
     }
 }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
@@ -28,7 +28,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static com.facebook.presto.release.git.TestingGitUtil.getCheckoutReleaseBranchAction;
-import static com.facebook.presto.release.maven.PrestoVersion.fromReleaseVersion;
+import static com.facebook.presto.release.maven.PrestoVersion.create;
 import static com.google.common.io.Files.copy;
 import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -75,7 +75,7 @@ public class TestFinalizeReleaseTask
     @Test
     public void testFinalizeRelease()
     {
-        git.setCheckoutAction(getCheckoutReleaseBranchAction(pomFile, fromReleaseVersion("0.231"))).setUpstreamHeads("0.231").setTags("0.230");
+        git.setCheckoutAction(getCheckoutReleaseBranchAction(pomFile, create("0.231"))).setUpstreamHeads("0.231").setTags("0.230");
         createTask(new VersionConfig()).run();
         assertCommands(commandLogger);
     }
@@ -83,7 +83,7 @@ public class TestFinalizeReleaseTask
     @Test
     public void testFinalizeReleaseExplicit()
     {
-        git.setCheckoutAction(getCheckoutReleaseBranchAction(pomFile, fromReleaseVersion("0.231"))).setUpstreamHeads("0.231").setTags("0.230");
+        git.setCheckoutAction(getCheckoutReleaseBranchAction(pomFile, create("0.231"))).setUpstreamHeads("0.231").setTags("0.230");
         createTask(new VersionConfig().setReleaseVersion("0.231")).run();
         assertCommands(commandLogger);
     }
@@ -91,7 +91,7 @@ public class TestFinalizeReleaseTask
     @Test
     public void testFinalizeReleaseHotFix()
     {
-        git.setCheckoutAction(getCheckoutReleaseBranchAction(pomFile, fromReleaseVersion("0.231.1"))).setUpstreamHeads("0.231").setTags("0.231");
+        git.setCheckoutAction(getCheckoutReleaseBranchAction(pomFile, create("0.231.1"))).setUpstreamHeads("0.231").setTags("0.231");
         createTask(new VersionConfig().setReleaseVersion("0.231.1")).run();
         assertCommandsHotFix(commandLogger);
     }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestFinalizeReleaseTask.java
@@ -28,7 +28,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static com.facebook.presto.release.git.TestingGitUtil.getCheckoutReleaseBranchAction;
-import static com.facebook.presto.release.maven.MavenVersion.fromReleaseVersion;
+import static com.facebook.presto.release.maven.PrestoVersion.fromReleaseVersion;
 import static com.google.common.io.Files.copy;
 import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;


### PR DESCRIPTION
Refactor around `MavenVersion` to support custom child classes. The goal is to allow `AbstractFinalizeReleaseTask` to support finalizing releases of different implementation of `MavenVersion`.