### PR TITLE
Add a contributors section at the bottom of each release note

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
@@ -77,6 +77,7 @@ public class GithubGraphQlAction
             "                                      }\n" +
             "                                      mergedBy {\n" +
             "                                          ... on User {\n" +
+            "                                              login\n" +
             "                                              name\n" +
             "                                          }\n" +
             "                                      }\n" +

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/PullRequest.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/PullRequest.java
@@ -28,7 +28,7 @@ public class PullRequest
     private final String url;
     private final String description;
     private final String authorLogin;
-    private final Optional<String> mergedBy;
+    private final Optional<User> mergedBy;
 
     @JsonCreator
     public PullRequest(
@@ -44,7 +44,7 @@ public class PullRequest
         this.url = requireNonNull(url, "url is null");
         this.description = requireNonNull(description, "description is null");
         this.authorLogin = requireNonNull(author.getLogin(), "authorLogin is null");
-        this.mergedBy = Optional.ofNullable(mergedBy).flatMap(User::getName);
+        this.mergedBy = Optional.ofNullable(mergedBy);
     }
 
     public int getId()
@@ -72,7 +72,7 @@ public class PullRequest
         return authorLogin;
     }
 
-    public Optional<String> getMergedBy()
+    public Optional<User> getMergedBy()
     {
         return mergedBy;
     }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/User.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/User.java
@@ -19,12 +19,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 
 public class User
+        extends Actor
 {
     private final Optional<String> name;
 
     @JsonCreator
-    public User(@JsonProperty("name") String name)
+    public User(@JsonProperty("login") String login, @JsonProperty("name") String name)
     {
+        super(login);
         this.name = Optional.ofNullable(name);
     }
 

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
@@ -77,18 +77,20 @@ public class TestGenerateReleaseNotesTask
     private static final String VERSION = "0.231";
     private static final String COMMIT_HASH_PREFIX = Joiner.on("").join(nCopies(30, "a"));
 
-    private static final Person USER1 = new Person("user1@gmail.com", "user1");
-    private static final Person USER2 = new Person("user2@gmail.com", "user2");
-    private static final Person USER3 = new Person("user3@gmail.com", "user3");
+    private static final Person USER1 = new Person("user1@gmail.com", "A Brown");
+    private static final Person USER1_GITHUB = new Person("user1@gmail.com", "AA Brown");
+    private static final Person USER2 = new Person("user2@gmail.com", "C Davis");
+    private static final Person USER3 = new Person("user3@gmail.com", "E Fisher");
+    private static final Person USER4 = new Person("user4@gmail.com", "G Harris");
 
     private static final AtomicInteger PullRequestId = new AtomicInteger(1);
     private static final AtomicInteger commitId = new AtomicInteger(1);
 
     private static final List<Commit> COMMITS = ImmutableList.<Commit>builder()
             .addAll(createCommits("release notes 1", USER1, USER1, true, 1))
-            .addAll(createCommits("release notes 2", USER2, USER1, true, 2))
+            .addAll(createCommits("release notes 2", USER2, USER1_GITHUB, true, 2))
             .addAll(createCommits("no release note", USER3, USER1, true, 1))
-            .addAll(createCommits("no release notes", USER1, USER2, true, 2))
+            .addAll(createCommits("no release notes", USER1, USER4, true, 2))
             .addAll(createCommits("missing release note", USER3, USER2, true, 2))
             .addAll(createCommits("missing section header 1", USER2, USER1, true, 1))
             .addAll(createCommits("missing section header 2", USER1, USER1, true, 1))
@@ -207,7 +209,7 @@ public class TestGenerateReleaseNotesTask
 
         public User getUser()
         {
-            return new User(name);
+            return new User(login, name);
         }
 
         public GitActor getGitActor()

--- a/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
@@ -1,39 +1,39 @@
 # Missing Release Notes
-## user1
-- [ ] https://github.com/prestodb/presto/pull/7 missing section header 2 (Merged by: user1)
-- [ ] https://github.com/prestodb/presto/pull/8 missing section header 3 (Merged by: user1)
+## A Brown
+- [ ] https://github.com/prestodb/presto/pull/7 missing section header 2 (Merged by: A Brown)
+- [ ] https://github.com/prestodb/presto/pull/8 missing section header 3 (Merged by: A Brown)
 
-## user2
-- [ ] https://github.com/prestodb/presto/pull/6 missing section header 1 (Merged by: user1)
+## C Davis
+- [ ] https://github.com/prestodb/presto/pull/6 missing section header 1 (Merged by: A Brown)
 
-## user3
-- [ ] https://github.com/prestodb/presto/pull/5 missing release note (Merged by: user2)
-- [ ] https://github.com/prestodb/presto/pull/9 missing asterisk (Merged by: user2)
+## E Fisher
+- [ ] https://github.com/prestodb/presto/pull/5 missing release note (Merged by: C Davis)
+- [ ] https://github.com/prestodb/presto/pull/9 missing asterisk (Merged by: C Davis)
 - [ ] aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13 disassociated commit - commit #1
 
 # Extracted Release Notes
-- #1 (Author: user1): release notes 1
+- #1 (Author: A Brown): release notes 1
   - Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
   - Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
   - Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
   - Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.
-- #2 (Author: user2): release notes 2
+- #2 (Author: C Davis): release notes 2
   - Improve correctness check for RowType columns. Add specific validation checks for the individual fields when validating a row column.
   - Remove unused FilterVoidLambda interface in ArrayFilterFunction.
   - Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
   - Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
 
 # All Commits
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01 release notes 1 - commit #1 (user1)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa02 release notes 2 - commit #1 (user2)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa03 release notes 2 - commit #2 (user2)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa04 no release note - commit #1 (user3)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05 no release notes - commit #1 (user1)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa06 no release notes - commit #2 (user1)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa07 missing release note - commit #1 (user3)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa08 missing release note - commit #2 (user3)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa09 missing section header 1 - commit #1 (user2)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa10 missing section header 2 - commit #1 (user1)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11 missing section header 3 - commit #1 (user1)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12 missing asterisk - commit #1 (user3)
-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13 disassociated commit - commit #1 (user3)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01 release notes 1 - commit #1 (A Brown)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa02 release notes 2 - commit #1 (C Davis)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa03 release notes 2 - commit #2 (C Davis)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa04 no release note - commit #1 (E Fisher)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05 no release notes - commit #1 (A Brown)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa06 no release notes - commit #2 (A Brown)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa07 missing release note - commit #1 (E Fisher)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa08 missing release note - commit #2 (E Fisher)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa09 missing section header 1 - commit #1 (C Davis)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa10 missing section header 2 - commit #1 (A Brown)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11 missing section header 3 - commit #1 (A Brown)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12 missing asterisk - commit #1 (E Fisher)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13 disassociated commit - commit #1 (E Fisher)

--- a/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
@@ -21,3 +21,8 @@ ______________
 * Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
 * Remove unused FilterVoidLambda interface in ArrayFilterFunction.
 * Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+
+**Contributors**
+================
+
+A Brown, C Davis, E Fisher, G Harris


### PR DESCRIPTION
We'd like to give credits to all the contributors, similar to what Spark is doing: https://spark.apache.org/releases/spark-release-3-0-0.html

The list of name includes all PR authors and PR committers within the release.

Example Result: https://github.com/prestodb/presto/pull/15291/files#diff-1e8973cca5a81e71ac9c1efdfef41081R45-R48