### PR TITLE
Remove double quote of a var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
                         echo ${DOCKERHUB_PRESTODB_CREDS_PSW} | docker login --username ${DOCKERHUB_PRESTODB_CREDS_USR} --password-stdin
                         IMAGE_SHAS=$(docker buildx imagetools inspect --raw "${DOCKER_IMAGE}" | jq -r '.manifests.[].digest')
                         ORG_IMG_NAME=${DOCKER_IMAGE%:*}
-                        for image_sha in "${IMAGE_SHAS}"; do
+                        for image_sha in ${IMAGE_SHAS}; do
                             docker buildx imagetools create --builder="container" -t "${DOCKER_PUBLIC}/presto@${image_sha}" "${ORG_IMG_NAME}@${image_sha}"
                         done
                         docker buildx imagetools create --builder="container" -t "${DOCKER_PUBLIC}/presto:${PRESTO_EDGE_RELEASE_VERSION}" "${DOCKER_IMAGE}"


### PR DESCRIPTION
In order to iterate through a list of image SHAs,
no need to have double quote for a var. Otherwise, the whole multiple line would be treated as one entry.