### PR TITLE
Add team-releases as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,9 +4,8 @@
 
 #####################################################################
 # Fallback to committers group for areas that do not have code owners
-/** @prestodb/committers
+/** @prestodb/committers @prestodb/team-releases
 
 # TSC may approve changes to this list
-CODEOWNERS @prestodb/team-tsc
-
+CODEOWNERS @prestodb/team-tsc 
 #####################################################################


### PR DESCRIPTION
This is consistent with previous commit privileges and CONTRIBUTING.md