### PR TITLE
Add github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish release
         run: |
           export GPG_TTY=$(tty)
-          export NEXUS_USERNAME=${{ vars.NEXUS_USERNAME }}
+          export NEXUS_USERNAME=${{ secrets.NEXUS_USERNAME }}
           export NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}
           export GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}
           mvn -Dgpg.useagent=true -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" package gpg:sign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    environment: release
+    strategy:
+      fail-fast: true
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Check branch
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: echo "Invalid branch. This action can only be run on the master branch." && exit 1
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          show-progress: false
+          fetch-depth: 0
+          ref: master
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Configure Maven settings.xml
+        run: |
+          mkdir -p ~/.m2
+          echo '<settings>' > ~/.m2/settings.xml
+          echo '  <servers>' >> ~/.m2/settings.xml
+          echo '    <server>' >> ~/.m2/settings.xml
+          echo '      <id>ossrh</id>' >> ~/.m2/settings.xml
+          echo '      <username>${env.NEXUS_USERNAME}</username>' >> ~/.m2/settings.xml
+          echo '      <password>${env.NEXUS_PASSWORD}</password>' >> ~/.m2/settings.xml
+          echo '    </server>' >> ~/.m2/settings.xml
+          echo '  </servers>' >> ~/.m2/settings.xml
+          echo '</settings>' >> ~/.m2/settings.xml
+          cat ~/.m2/settings.xml
+
+      - name: Set up git
+        run: |
+          git config --global --add safe.directory ${{github.workspace}}
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
+          git config pull.rebase false
+
+      - name: Set up GPG key
+        run: |
+          echo "${{ secrets.GPG_SECRET }}" > ${{ github.workspace }}/secret-key.gpg
+          chmod 600 ${{ github.workspace }}/secret-key.gpg
+          gpg --import --batch ${{ github.workspace }}/secret-key.gpg
+          rm -f ${{ github.workspace }}/secret-key.gpg
+          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+          echo "use-agent" > ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          gpg-connect-agent reloadagent /bye
+
+      - name: Prepare release
+        run: |
+          mvn release:prepare
+
+      - name: Publish release
+        run: |
+          export GPG_TTY=$(tty)
+          export NEXUS_USERNAME=${{ vars.NEXUS_USERNAME }}
+          export NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}
+          export GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}
+          mvn -Dgpg.useagent=true -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" package gpg:sign
+          mvn release:perform
+
+      - name: Push changes and tags
+        run: |
+          git push origin master --tags


### PR DESCRIPTION
Tested (skipped the publishing to ossrh) with this repo => https://github.com/unix280/presto-release-tools/actions/runs/13167010234/job/36749433301

## Environment Setup

1. Navigate to your GitHub repository settings
2. Go to "Settings" → "Environments"
3. Click "New environment"
4. Create an environment named `release`

## Required Secrets and Variables

### Secrets
Add the following secrets in your environment settings (Settings → Environments → release → Add secret):

| Secret Name | Description |
|------------|-------------|
| `PRESTODB_CI_TOKEN` | GitHub Personal Access Token with repo permissions for checkout |
| `NEXUS_PASSWORD` | Password for Maven Central (Sonatype OSSRH) deployment |
| `GPG_SECRET` | GPG private key for signing artifacts |
| `GPG_PASSPHRASE` | Passphrase for the GPG private key |

### Variables
Add the following variable in environment settings (Settings → Environments → release → Add variable):

| Variable Name | Description |
|--------------|-------------|
| `NEXUS_USERNAME` | Username for Maven Central (Sonatype OSSRH) deployment |
