### PR TITLE
Fix env variables in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Publish release
         run: |
           export GPG_TTY=$(tty)
-          export NEXUS_USERNAME=${{ secrets.NEXUS_USERNAME }}
-          export NEXUS_PASSWORD=${{ secrets.NEXUS_PASSWORD }}
-          export GPG_PASSPHRASE=${{ secrets.GPG_PASSPHRASE }}
+          export NEXUS_USERNAME="${{ secrets.NEXUS_USERNAME }}"
+          export NEXUS_PASSWORD="${{ secrets.NEXUS_PASSWORD }}"
+          export GPG_PASSPHRASE="${{ secrets.GPG_PASSPHRASE }}"
           mvn -Dgpg.useagent=true -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" package gpg:sign
           mvn release:perform
 


### PR DESCRIPTION
From the error log, seems the GPG_PASSPHRASE contains some special characters like `;`, add the double quotes to prevent this error. 

```
export GPG_TTY=$(tty)
  export NEXUS_USERNAME=***
  export NEXUS_PASSWORD=***
  export GPG_PASSPHRASE=***
  mvn -Dgpg.useagent=true -Dgpg.passphrase="***" package gpg:sign
  mvn release:perform
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/8.0.442-6/x64
    JAVA_HOME_8_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/8.0.442-6/x64
/home/runner/work/_temp/beaa806d-b9d2-49a[3](https://github.com/prestodb/presto-release-tools/actions/runs/13186380966/job/36809332169#step:9:3)-ad22-6f4972b2d74f.sh: line [4](https://github.com/prestodb/presto-release-tools/actions/runs/13186380966/job/36809332169#step:9:4): **: command not found
Error: Process completed with exit code 127.
```