### PR TITLE
Remove hardcoded repository id to make it work in release actions

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/Git.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/Git.java
@@ -46,5 +46,7 @@ public interface Git
 
     String status(String... options);
 
+    String remoteUrl(String remote);
+
     List<String> tag();
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitCommands.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitCommands.java
@@ -151,4 +151,10 @@ public class GitCommands
         }
         return sshKeyFile.map(s -> ImmutableMap.of("GIT_SSH_COMMAND", format("ssh -i %s", s))).orElseGet(ImmutableMap::of);
     }
+
+    @Override
+    public String remoteUrl(String remote)
+    {
+        return command("remote", "get-url", remote).trim();
+    }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepository.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GitRepository.java
@@ -145,4 +145,16 @@ public class GitRepository
             checkArgument(directory.getName().equals(repositoryName), "Directory name [%s] mismatches repository name [%s]", directory.getName(), repositoryName);
         }
     }
+
+    public static String getRepositoryFromUrl(String repositoryUrl)
+    {
+        String repo;
+        if (repositoryUrl.startsWith("git")) {
+            repo = repositoryUrl.replaceAll("^[^:]+:", "");
+        }
+        else {
+            repo = repositoryUrl.replaceAll("^https?://[^/]+/", "");
+        }
+        return repo.replaceAll("\\.git$", "");
+    }
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubAction.java
@@ -23,7 +23,7 @@ public interface GithubAction
     List<Commit> listCommits(String branch, String earliest);
 
     /**
-     * Create a pull request to merge from origin/branch to upstream/master.
+     * Create a pull request to merge from headRef to baseRef
      */
-    PullRequest createPullRequest(String branch, String title, String body);
+    PullRequest createPullRequest(String repository, String baseRef, String headRef, String title, String body);
 }

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubAction.java
@@ -20,7 +20,7 @@ public interface GithubAction
     /**
      * List commits starting from {@code earliest}, inclusive, on {@code branch}.
      */
-    List<Commit> listCommits(String branch, String earliest);
+    List<Commit> listCommits(String repository, String branch, String earliest);
 
     /**
      * Create a pull request to merge from headRef to baseRef

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
@@ -131,14 +131,19 @@ public class GithubGraphQlAction
         this.accessToken = requireNonNull(githubConfig.getAccessToken(), "accessToken is null");
     }
 
-    @Override
-    public List<Commit> listCommits(String repository, String branch, String earliest)
+    private String[] parseRepository(String repository)
     {
         String[] parts = repository.split("/");
         if (parts.length != 2) {
             throw new IllegalArgumentException("Repository must be in format 'owner/name'");
         }
+        return parts;
+    }
 
+    @Override
+    public List<Commit> listCommits(String repository, String branch, String earliest)
+    {
+        String[] parts = parseRepository(repository);
         String current = null;
         ImmutableList.Builder<Commit> commits = ImmutableList.builder();
         TypeReference<Map<String, Map<String, Map<String, Map<String, Map<String, CommitHistory>>>>>> returnType = new TypeReference<Map<String, Map<String, Map<String, Map<String, Map<String, CommitHistory>>>>>>() {};
@@ -166,11 +171,7 @@ public class GithubGraphQlAction
     @Override
     public PullRequest createPullRequest(String repository, String baseRef, String headRef, String title, String body)
     {
-        String[] parts = repository.split("/");
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Repository must be in format 'owner/name'");
-        }
-
+        String[] parts = parseRepository(repository);
         TypeReference<Map<String, Map<String, Map<String, String>>>> repoIdType =
                 new TypeReference<Map<String, Map<String, Map<String, String>>>>() {};
 

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -172,7 +172,22 @@ public class GenerateReleaseNotesTask
         createReleaseNotesCommit(version.getVersion(), releaseNotesBranch, releaseNotes);
         git.push(ORIGIN, releaseNotesBranch, false);
 
-        PullRequest releaseNotesPullRequest = githubAction.createPullRequest(releaseNotesBranch, format("Add release notes for %s", version.getVersion()), releaseNotesSummary);
+        String upstreamName = repository.getUpstreamName();
+        String upstreamUrl = git.remoteUrl(upstreamName);
+        String upstreamRepo = GitRepository.getRepositoryFromUrl(upstreamUrl);
+        log.info("upstream url: %s, repo: %s", upstreamUrl, upstreamRepo);
+
+        String originName = repository.getOriginName();
+        String originUrl = git.remoteUrl(originName);
+        String originRepo = GitRepository.getRepositoryFromUrl(originUrl);
+        log.info("origin url: %s, repo: %s", originUrl, originRepo);
+
+        PullRequest releaseNotesPullRequest = githubAction.createPullRequest(
+                upstreamRepo,
+                "master",
+                format("%s:%s", originRepo.split("/")[0], releaseNotesBranch),
+                format("Add release notes for %s", version.getVersion()),
+                releaseNotesSummary);
         log.info("Release notes pull request created: %s", releaseNotesPullRequest.getUrl());
     }
 

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
@@ -31,7 +31,7 @@ public class MockGithubAction
     }
 
     @Override
-    public List<Commit> listCommits(String latest, String earliest)
+    public List<Commit> listCommits(String repository, String latest, String earliest)
     {
         return commits;
     }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
@@ -37,7 +37,7 @@ public class MockGithubAction
     }
 
     @Override
-    public PullRequest createPullRequest(String branch, String title, String body)
+    public PullRequest createPullRequest(String repository, String baseRef, String headRef, String title, String body)
     {
         checkState(pullRequest == null, "Can only create one pull request");
         pullRequest = new PullRequest(0, title, "", body, new Actor("test"), null);

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/git/MockGithubAction.java
@@ -23,6 +23,8 @@ public class MockGithubAction
         implements GithubAction
 {
     private final List<Commit> commits;
+    private String pullRequestRepository;
+    private String listCommitsRepository;
     private PullRequest pullRequest;
 
     public MockGithubAction(List<Commit> commits)
@@ -33,12 +35,14 @@ public class MockGithubAction
     @Override
     public List<Commit> listCommits(String repository, String latest, String earliest)
     {
+        this.listCommitsRepository = repository;
         return commits;
     }
 
     @Override
     public PullRequest createPullRequest(String repository, String baseRef, String headRef, String title, String body)
     {
+        this.pullRequestRepository = repository;
         checkState(pullRequest == null, "Can only create one pull request");
         pullRequest = new PullRequest(0, title, "", body, new Actor("test"), null);
         return pullRequest;
@@ -47,5 +51,15 @@ public class MockGithubAction
     public PullRequest getCreatedPullRequest()
     {
         return pullRequest;
+    }
+
+    public String getPullRequestRepository()
+    {
+        return pullRequestRepository;
+    }
+
+    public String getListCommitsRepository()
+    {
+        return listCommitsRepository;
     }
 }

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
@@ -71,6 +71,19 @@ public class TestGenerateReleaseNotesTask
         {
             return "96d1a0420c46ed6a2442a3598dad5e7c9599e9c1\neacf13484139a85c53901f2045578c659a65a5b2";
         }
+
+        @Override
+        public String remoteUrl(String remote)
+        {
+            switch (remote) {
+                case "upstream":
+                    return "https://github.com/org/presto.git";
+                case "origin":
+                    return "https://github.com/user/presto.git";
+                default:
+                    return super.remoteUrl(remote);
+            }
+        }
     }
 
     private static final String RESOURCE_DIRECTORY = "release-notes-test";
@@ -134,6 +147,8 @@ public class TestGenerateReleaseNotesTask
         assertEquals(asCharSource(releaseNotesListFile, UTF_8).read(), getTestResourceContent("release_expected.rst"));
         assertEquals(asCharSource(releaseNotesFile, UTF_8).read(), getTestResourceContent("release-0.231_expected.rst"));
         assertEquals(githubAction.getCreatedPullRequest().getDescription().trim(), getTestResourceContent("description_expected.txt").trim());
+        assertEquals(githubAction.getPullRequestRepository(), "org/presto");
+        assertEquals(githubAction.getListCommitsRepository(), "org/presto");
     }
 
     private GenerateReleaseNotesTask initializeTask(List<Commit> commits)


### PR DESCRIPTION
The PR is intend to 
1. Delete the hardcoded repository id for release notes PR.
2. Make the release-notes PR can be requested from the same repository( so that it can be used in release actions)
3. Use graphql to get repository id from `upstream` repository name

After removed, it helps to
1. Adopt by the release action since the repo running the action is not a fork repo
2. Enable test env so that it won't create the release-notes PR to prestodb/presto repository
3. Can be reused by other repositories
