### PR TITLE
Add javadoc plugin and fix signature for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Set up git
         run: |
@@ -77,11 +76,19 @@ jobs:
           git log --pretty="format:%ce: %s" -4
           cat ~/.m2/settings.xml
           cd presto-release-tools
-          mvn package gpg:sign deploy -Pdeploy-to-ossrh
+          mvn javadoc:jar package gpg:sign 
+
+          for file in target/*.jar; do
+            echo "Verifying signature for $file"
+            gpg --verify "$file.asc" "$file"
+          done
+
+          mvn deploy -Pdeploy-to-ossrh
           cd ..
         env:
           NEXUS_USERNAME: "${{ secrets.NEXUS_USERNAME }}"
           NEXUS_PASSWORD: "${{ secrets.NEXUS_PASSWORD }}"
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
 
       - name: Push changes and tags
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,13 +76,6 @@ jobs:
           git log --pretty="format:%ce: %s" -4
           cat ~/.m2/settings.xml
           cd presto-release-tools
-          mvn javadoc:jar package gpg:sign 
-
-          for file in target/*.jar; do
-            echo "Verifying signature for $file"
-            gpg --verify "$file.asc" "$file"
-          done
-
           mvn deploy -Pdeploy-to-ossrh
           cd ..
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,36 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.11.2</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.7</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
                         <preparationGoals>clean verify -DskipTests</preparationGoals>
@@ -167,6 +197,14 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Fix the following errros in release action:
```
Error:  Rule failure while trying to close staging repository with ID "comfacebook-3993".
Error:  
Error:  Nexus Staging Rules Failure Report
Error:  ==================================
Error:  
Error:  Repository "comfacebook-3993" failures
Error:    Rule "javadoc-staging" failures
Error:      * Missing: no javadoc jar found in folder '/com/facebook/presto/presto-release-tools/0.9'
Error:    Rule "signature-staging" failures
Error:      * Invalid Signature: '/com/facebook/presto/presto-release-tools/0.9/presto-release-tools-0.9-test-sources.jar.asc' is not a valid signature for 'presto-release-tools-0.9-test-sources.jar'.
Error:      * Invalid Signature: '/com/facebook/presto/presto-release-tools/0.9/presto-release-tools-0.9.tar.gz.asc' is not a valid signature for 'presto-release-tools-0.9.tar.gz'.
Error:      * Invalid Signature: '/com/facebook/presto/presto-release-tools/0.9/presto-release-tools-0.9-sources.jar.asc' is not a valid signature for 'presto-release-tools-0.9-sources.jar'.
Error:      * Invalid Signature: '/com/facebook/presto/presto-release-tools/0.9/presto-release-tools-0.9-executable.jar.asc' is not a valid signature for 'presto-release-tools-0.9-executable.jar'.
Error:  
Error:  
Error:  Cleaning up local stage directory after a Rule failure during close of staging repositories: [comfacebook-3993]
Error:   * Deleting context 28a0d8c4350ed.properties
Error:  Cleaning up remote stage repositories after a Rule failure during close of staging repositories: [comfacebook-3993]
Error:   * Dropping failed staging repository with ID "comfacebook-3993" (Rule failure during close of staging repositories: [comfacebook-3993]).
```