### PR TITLE
Add command to check PR description for release notes

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/PrestoReleaseService.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/PrestoReleaseService.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.release;
 
+import com.facebook.presto.release.tasks.CheckReleaseNotesCommand;
 import com.facebook.presto.release.tasks.CutReleaseCommand;
 import com.facebook.presto.release.tasks.FinalizeReleaseCommand;
 import com.facebook.presto.release.tasks.GenerateReleaseNotesCommand;
@@ -35,6 +36,7 @@ public class PrestoReleaseService
                 .withDefaultCommand(Help.class)
                 .withCommand(Help.class)
                 .withCommand(GenerateReleaseNotesCommand.class)
+                .withCommand(CheckReleaseNotesCommand.class)
                 .withCommand(CutReleaseCommand.class)
                 .withCommand(FinalizeReleaseCommand.class)
                 .build();

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CheckReleaseNotesCommand.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CheckReleaseNotesCommand.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+import io.airlift.airline.Command;
+
+import java.util.List;
+
+@Command(name = "check-release-notes", description = "Checks the text of a PR description to ensure the release notes can be properly parsed.")
+public class CheckReleaseNotesCommand
+        extends AbstractReleaseCommand
+{
+    @Override
+    protected List<Module> getModules()
+    {
+        return ImmutableList.of(new CheckReleaseNotesModule());
+    }
+
+    @Override
+    protected Class<? extends ReleaseTask> getReleaseTask()
+    {
+        return CheckReleaseNotesTask.class;
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CheckReleaseNotesModule.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CheckReleaseNotesModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.google.inject.Scopes.SINGLETON;
+
+public class CheckReleaseNotesModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(CheckReleaseNotesTask.class).in(SINGLETON);
+    }
+}

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CheckReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/CheckReleaseNotesTask.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.release.git.Actor;
+import com.facebook.presto.release.git.PullRequest;
+import com.facebook.presto.release.git.User;
+import com.facebook.presto.release.tasks.GenerateReleaseNotesTask.ReleaseNoteItem;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.NO_RELEASE_NOTE_PATTERN;
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.RELEASE_NOTE_PATTERN;
+import static com.facebook.presto.release.tasks.GenerateReleaseNotesTask.extractReleaseNotes;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.io.ByteStreams.toByteArray;
+import static com.google.common.io.Resources.getResource;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+
+public class CheckReleaseNotesTask
+        implements ReleaseTask
+{
+    private static final Logger log = Logger.get(CheckReleaseNotesTask.class);
+
+    private static final List<Pattern> VALID_SECTION_REGEXES = ImmutableList.of(
+                    "^General.*",
+                    "^Prestissimo (Native Execution)",
+                    "^Security.*",
+                    "^JDBC.*",
+                    "^Web UI.*",
+                    ".* Connector.*",
+                    ".* Plugin.*",
+                    "^Verifier.*",
+                    "^SPI.*",
+                    "^Resource Groups.*",
+                    "^Documentation.*")
+            .stream().map(Pattern::compile)
+            .collect(toImmutableList());
+
+    private static final List<String> VALID_STARTING_VERBS = ImmutableList.of(
+            "Fix",
+            "Improve",
+            "Add",
+            "Replace",
+            "Rename",
+            "Remove",
+            "Upgrade",
+            "Downgrade");
+
+    private final String releaseNoteSectionTemplate;
+
+    public CheckReleaseNotesTask()
+    {
+        try {
+            this.releaseNoteSectionTemplate = Resources.toString(getResource("note_template.md"), StandardCharsets.UTF_8);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void run()
+    {
+        try {
+            String prDescription = new String(toByteArray(System.in), StandardCharsets.UTF_8);
+            checkReleaseNotes(prDescription);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @VisibleForTesting
+    protected void checkReleaseNotes(String prDescription)
+    {
+        ImmutableList.Builder<Exception> errorTracker = ImmutableList.builder();
+        errorTracker.addAll(verifyReleaseNoteSections(prDescription));
+
+        PullRequest pullRequest = new PullRequest(
+                0,
+                "pull request release note check",
+                "",
+                prDescription,
+                new Actor("prestodb-ci"),
+                new User("prestodb-ci", "prestodb-ci"));
+        Optional<List<ReleaseNoteItem>> notes = extractReleaseNotes(pullRequest);
+        notes.ifPresent(releaseNotes -> releaseNotes.forEach(note -> {
+            errorTracker.addAll(verifyReleaseNoteItem(note));
+        }));
+        if (!notes.isPresent()) {
+            errorTracker.add(new Exception("Release notes not found"));
+        }
+
+        List<Exception> errors = errorTracker.build();
+
+        if (!errors.isEmpty()) {
+            errors.forEach(exception -> log.error(exception.getMessage()));
+            throw new RuntimeException("Errors encountered while parsing release notes");
+        }
+        else {
+            log.info("release notes found:%n%s", Joiner.on("\n")
+                    .join(notes.get().stream()
+                            .map(note -> note.getFormatted("*", 1))
+                            .iterator()));
+        }
+    }
+
+    public List<Exception> verifyReleaseNoteItem(ReleaseNoteItem item)
+    {
+        return ImmutableList.<Optional<Exception>>builder()
+                .add(verify(VALID_SECTION_REGEXES.stream().anyMatch(pattern -> pattern.matcher(item.getSection()).find()),
+                        format("The release note section '%s' must match one of the valid regex patterns: %s", item.getSection(), Joiner.on(",").join(VALID_SECTION_REGEXES))))
+                .add(verify(VALID_STARTING_VERBS.stream().anyMatch(verb -> item.getLine().toLowerCase(ENGLISH).startsWith(verb.toLowerCase(ENGLISH))),
+                        format("The release note line '%s' must start with one of the valid verbs: %s", item.getLine(), Joiner.on(",").join(VALID_STARTING_VERBS))))
+                .build()
+                .stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toImmutableList());
+    }
+
+    public List<Exception> verifyReleaseNoteSections(String prDescription)
+    {
+        return ImmutableList.<Optional<Exception>>builder()
+                .add(verify(!prDescription.contains(releaseNoteSectionTemplate), "The PR description may not contain the release note template."))
+                .add(verify(!(RELEASE_NOTE_PATTERN.matcher(prDescription).find() && NO_RELEASE_NOTE_PATTERN.matcher(prDescription).find()),
+                        "The PR description must contain only one instance of == RELEASE NOTES == or == NO RELEASE NOTE =="))
+                .build()
+                .stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toImmutableList());
+    }
+
+    public Optional<Exception> verify(boolean check, String message)
+    {
+        return Optional.of(check)
+                .filter(b -> !b)
+                .map(b -> new Exception(message));
+    }
+}

--- a/presto-release-tools/src/main/resources/note_template.md
+++ b/presto-release-tools/src/main/resources/note_template.md
@@ -1,0 +1,20 @@
+## Release Notes
+Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
+
+```
+== RELEASE NOTES ==
+
+General Changes
+* ... 
+* ... 
+
+Hive Connector Changes
+* ... 
+* ... 
+```
+
+If release note is NOT required, use:
+
+```
+== NO RELEASE NOTE ==
+```

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.release.tasks;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static com.facebook.presto.release.tasks.TestGenerateReleaseNotesTask.getTestResourceContent;
+import static org.testng.Assert.fail;
+
+public class TestCheckReleaseNotesTask
+{
+    private static final Map<String, Boolean> releaseNoteStatus = ImmutableMap.<String, Boolean>builder()
+            .put("missing_asterisk.txt", false)
+            .put("missing_release_note.txt", false)
+            .put("missing_section_header_1.txt", false)
+            .put("missing_section_header_2.txt", false)
+            .put("missing_section_header_3.txt", false)
+            .put("no_release_note.txt", true)
+            .put("no_release_notes.txt", true)
+            .put("release_notes_1.txt", true)
+            .put("release_notes_2.txt", true)
+            .build();
+
+    private CheckReleaseNotesTask checkReleaseNotesTask = new CheckReleaseNotesTask();
+
+    @DataProvider(name = "releaseNotes")
+    private Object[][] examplesProvider()
+    {
+        return releaseNoteStatus.entrySet().stream()
+                .map(entry -> new Object[] {entry.getKey(), entry.getValue()})
+                .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "releaseNotes")
+    public void testCheckReleaseNotes(String resourceName, boolean expectedReleaseNoteStatus)
+            throws IOException
+    {
+        String content = getTestResourceContent("pr", resourceName);
+        try {
+            checkReleaseNotesTask.checkReleaseNotes(content);
+            if (!expectedReleaseNoteStatus) {
+                fail("Expected failure to resolve release notes");
+            }
+        }
+        catch (Exception e) {
+            if (expectedReleaseNoteStatus) {
+                fail("Expected success to resolve release notes");
+            }
+        }
+    }
+
+    @DataProvider(name = "releaseNotesFailures")
+    public Object[][] releaseNotesFailures()
+            throws IOException
+    {
+        return new Object[][] {
+                // no edit to template
+                {Resources.toString(Resources.getResource("note_template.md"), StandardCharsets.UTF_8)},
+                // ambiguous, double release note blocks
+                {"== RELEASE NOTES ==\n changes\n* asdasd\n\n\n== NO RELEASE NOTES =="},
+                // release note vs notes
+                {"== RELEASE NOTES ==\ngeneral\n* asd\n\n== RELEASE NOTE ==\ngeneral\n* asd"},
+                {"== RELEASE NOTES ==\ngeneral\n* asd\n\n== RELEASE NOTES ==\ngeneral\n* asd"},
+                // invalid section titles
+                {"== RELEASE NOTES ==\n\ngenerel chang\ntest"},
+                {"== RELEASE NOTES ==\n\ngeneral changes\ntest"},
+                {"== RELEASE NOTES ==\n\ncustom section\n* test"},
+                // invalid note starts
+                {"== RELEASE NOTES ==\n\nGeneral Changes\n* test a thing"},
+                {"== RELEASE NOTES ==\n\nGeneral Changes\ntest a thing"},
+                {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n* enhance a thing"},
+                // multiple sections, one invalid section title
+                {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSNI changes\n* Add an SPI thing"},
+                // multiple sections one invalid release note verb
+                {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing"},
+        };
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, dataProvider = "releaseNotesFailures")
+    public void testInvalidReleaseNotes(String notes)
+            throws IOException
+    {
+        checkReleaseNotesTask.checkReleaseNotes(notes);
+    }
+}

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
@@ -200,7 +200,7 @@ public class TestGenerateReleaseNotesTask
         return Resources.getResource(Paths.get(RESOURCE_DIRECTORY, path).toString());
     }
 
-    private static String getTestResourceContent(String... path)
+    public static String getTestResourceContent(String... path)
             throws IOException
     {
         return Resources.toString(getTestResource(path), UTF_8);

--- a/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
@@ -13,7 +13,7 @@
 
 # Extracted Release Notes
 - #1 (Author: A Brown): release notes 1
-  - Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+  - Improve ``storage.data-directory` type. Changes the type from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
   - Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
   - Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
   - Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.
@@ -21,7 +21,7 @@
   - Improve correctness check for RowType columns. Add specific validation checks for the individual fields when validating a row column.
   - Remove unused FilterVoidLambda interface in ArrayFilterFunction.
   - Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
-  - Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
+  - Improve the ``ConnectorMetadata#commitPartition`` operation. Change it into an async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
 
 # All Commits
 - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01 release notes 1 - commit #1 (A Brown)

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
@@ -1,7 +1,7 @@
 == RELEASE NOTES ==
 
-Raptor Changes
-* Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+Raptor Plugin Changes
+* Improve ``storage.data-directory` type. Changes the type from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
 * Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
 * Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
 * Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
@@ -1,6 +1,6 @@
 == RELEASE NOTES ==
 
-Raptor Changes
+Raptor Plugin Changes
 --------------
 * Improve correctness check for RowType columns.
   Add specific validation checks for the individual fields when validating a row column.
@@ -8,4 +8,4 @@ Raptor Changes
 * Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
 SPI Changes
 -----------
-* Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``
+* Improve the ``ConnectorMetadata#commitPartition`` operation. Change it into an async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``

--- a/presto-release-tools/src/test/resources/release-notes-test/pr_template.md
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr_template.md
@@ -1,0 +1,43 @@
+## Description
+<!---Describe your changes in detail-->
+
+## Motivation and Context
+<!---Why is this change required? What problem does it solve?-->
+<!---If it fixes an open issue, please link to the issue here.-->
+
+## Impact
+<!---Describe any public API or user-facing feature change or any performance impact-->
+
+## Test Plan
+<!---Please fill in how you tested your change-->
+
+## Contributor checklist
+
+- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
+- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
+- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
+- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
+- [ ] Adequate tests were added if applicable.
+- [ ] CI passed.
+
+## Release Notes
+Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
+
+```
+== RELEASE NOTES ==
+
+General Changes
+* ... 
+* ... 
+
+Hive Connector Changes
+* ... 
+* ... 
+```
+
+If release note is NOT required, use:
+
+```
+== NO RELEASE NOTE ==
+```
+

--- a/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
@@ -10,17 +10,17 @@ Release 0.231
 
 SPI Changes
 ___________
-* Change ``ConnectorMetadata#commitPartition`` into async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``. `#2 <https://github.com/prestodb/presto/pull/2>`_
+* Improve the ``ConnectorMetadata#commitPartition`` operation. Change it into an async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``. `#2 <https://github.com/prestodb/presto/pull/2>`_
 
-Raptor Changes
-______________
+Raptor Plugin Changes
+_____________________
 * Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo. `#1 <https://github.com/prestodb/presto/pull/1>`_
+* Improve ``storage.data-directory` type. Changes the type from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value. `#1 <https://github.com/prestodb/presto/pull/1>`_
 * Improve correctness check for RowType columns. Add specific validation checks for the individual fields when validating a row column. `#2 <https://github.com/prestodb/presto/pull/2>`_
 * Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data. `#2 <https://github.com/prestodb/presto/pull/2>`_
 * Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``. `#1 <https://github.com/prestodb/presto/pull/1>`_
 * Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``. `#1 <https://github.com/prestodb/presto/pull/1>`_
 * Remove unused FilterVoidLambda interface in ArrayFilterFunction. `#2 <https://github.com/prestodb/presto/pull/2>`_
-* Change ``storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value. `#1 <https://github.com/prestodb/presto/pull/1>`_
 
 **Credits**
 ===========


### PR DESCRIPTION
Simple command which accepts text from stdin, and then determines if the text has extractable release notes. Intended to be used in GH actions checks. Exit code 0 indicates the PR has release notes (they will be printed to the console). Exit code 1 indicates no valid release note block. Errors and log messages are be printed to the console.

Examples
```
echo "${PR_DESCRIPTION} | ./presto-release-tools check-release-notes
```

Negative
```
zacblanco@zac-ibm presto-release-tools % echo "\nasdasd\nasdasdasd\nasdasd\n\n\n== RELEASE NOTES  ==\nGeneral Changes\n* test\n* check1" | ./presto-release-tools/target/presto-release-tools-0.10-SNAPSHOT-executable.jar check-release-notes
Apr 02, 2025 10:10:31 PM org.eclipse.jetty.util.log.Log initialized
INFO: Logging initialized @62ms to org.eclipse.jetty.util.log.Slf4jLog
2025-04-02T22:10:31.774-0700    INFO    main    com.facebook.airlift.log.Logging        Logging to stderr
2025-04-02T22:10:31.776-0700    INFO    main    Bootstrap       Loading configuration
2025-04-02T22:10:31.846-0700    INFO    main    Bootstrap       Initializing logging
2025-04-02T22:10:31.910-0700    INFO    main    Bootstrap       PROPERTY  DEFAULT  RUNTIME  DESCRIPTION
2025-04-02T22:10:31.973-0700    WARN    main    com.facebook.presto.release.tasks.GenerateReleaseNotesTask      Pull request description does not match release note pattern
2025-04-02T22:10:31.974-0700    ERROR   main    Bootstrap       Uncaught exception in thread main
java.lang.RuntimeException: release notes not found
        at com.facebook.presto.release.tasks.CheckReleaseNotesTask.checkReleaseNotes(CheckReleaseNotesTask.java:60)
        at com.facebook.presto.release.tasks.CheckReleaseNotesTask.run(CheckReleaseNotesTask.java:41)
        at com.facebook.presto.release.tasks.AbstractReleaseCommand.run(AbstractReleaseCommand.java:50)
        at com.facebook.presto.release.PrestoReleaseService.main(PrestoReleaseService.java:43)

```
Positive
```
zacblanco@zac-ibm presto-release-tools % echo "\nasdasd\nasdasdasd\nasdasd\n\n\n== RELEASE NOTES ==\nGeneral Changes\n* test\n* check1" | ./presto-release-tools/target/presto-release-tools-0.10-SNAPSHOT-executable.jar check-release-notes 
Apr 02, 2025 10:10:40 PM org.eclipse.jetty.util.log.Log initialized
INFO: Logging initialized @70ms to org.eclipse.jetty.util.log.Slf4jLog
2025-04-02T22:10:40.867-0700    INFO    main    com.facebook.airlift.log.Logging        Logging to stderr
2025-04-02T22:10:40.869-0700    INFO    main    Bootstrap       Loading configuration
2025-04-02T22:10:40.938-0700    INFO    main    Bootstrap       Initializing logging
2025-04-02T22:10:41.004-0700    INFO    main    Bootstrap       PROPERTY  DEFAULT  RUNTIME  DESCRIPTION
2025-04-02T22:10:41.073-0700    INFO    main    com.facebook.presto.release.tasks.CheckReleaseNotesTask release notes found:
 * Test.
 * Check1.

```

Example PR run: https://github.com/prestodb/presto/actions/runs/14229930609/job/39878204820?pr=24855