### PR TITLE
Deploy from presto-release-tools-root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,7 @@ jobs:
           git checkout ${{ env.RELEASE_VERSION }}
           git log --pretty="format:%ce: %s" -4
           cat ~/.m2/settings.xml
-          cd presto-release-tools
           mvn deploy -Pdeploy-to-ossrh
-          cd ..
         env:
           NEXUS_USERNAME: "${{ secrets.NEXUS_USERNAME }}"
           NEXUS_PASSWORD: "${{ secrets.NEXUS_PASSWORD }}"


### PR DESCRIPTION
The issue is that previously the release action only run deply command in `presto-release-tools`, which cause the maven command can not download it as dependency and use it in the release notes checking action in presto repo.

The failed command is
```
./mvnw -DgroupId=com.facebook.presto -DartifactId=presto-release-tools -Dversion=0.9 -Dpackaging=jar -Dclassifier=executable dependency:get
```

After release presto-release-tools-root, this issue should be fixed