### PR TITLE
Fix section ordering after updates to doc guide

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -89,15 +89,15 @@ public class GenerateReleaseNotesTask
     public static final List<Pattern> VALID_SECTION_HEADERS = ImmutableList.of(
                     "^General.*",
                     "^Prestissimo (Native Execution)",
-                    "^Security.*",
-                    "^JDBC.*",
-                    ".* Connector.*",
-                    "^Web UI.*",
-                    "^Verifier.*",
-                    "SPI",
-                    ".* Plugin.*",
-                    "^Resource Groups.*",
-                    "^Documentation.*")
+                    "^Security",
+                    "^JDBC Driver",
+                    "^Web UI",
+                    ".* Connector",
+                    "^Verifier",
+                    "^Resource Groups",
+                    "^SPI",
+                    ".* Plugin",
+                    "^Documentation")
             .stream().map(header -> Pattern.compile(header, CASE_INSENSITIVE))
             .collect(toImmutableList());
     private static final Pattern DASHES = Pattern.compile("-+$");


### PR DESCRIPTION
There were updates made to:
https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines#order-of-sections

This change accounts for the new updates