### PR TITLE
Add auto release artifacts flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           git checkout ${{ env.RELEASE_VERSION }}
           git log --pretty="format:%ce: %s" -4
           cat ~/.m2/settings.xml
-          mvn deploy -Pdeploy-to-ossrh
+          mvn deploy -Pdeploy-to-ossrh -DautoReleaseAfterClose=true
         env:
           NEXUS_USERNAME: "${{ secrets.NEXUS_USERNAME }}"
           NEXUS_PASSWORD: "${{ secrets.NEXUS_PASSWORD }}"


### PR DESCRIPTION
By the doc of [nexus-staging-maven-plugin 1.68](https://github.com/sonatype/nexus-maven-plugins/blob/nexus-maven-plugins-1.6.8/staging/maven-plugin/README.md#plugin-flags), the default value of flag `autoReleaseAfterClose` is false, which cause the published artifacts in `closed` state on https://oss.sonatype.org, we have to manually publish the artifacts with the admin console on https://oss.sonatype.org.

So add this flag to perform auto-release.

