### PR TITLE
Fix unescaped parens in release header format

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -88,7 +88,7 @@ public class GenerateReleaseNotesTask
     protected static final Pattern HEADER_PATTERN = Pattern.compile("(.*) change(s)$", CASE_INSENSITIVE);
     public static final List<Pattern> VALID_SECTION_HEADERS = ImmutableList.of(
                     "^General.*",
-                    "^Prestissimo (Native Execution)",
+                    "^Prestissimo \\(Native Execution\\)",
                     "^Security",
                     "^JDBC Driver",
                     "^Web UI",

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static com.facebook.presto.release.tasks.TestGenerateReleaseNotesTask.getTestResourceContent;
+import static java.lang.String.format;
 import static org.testng.Assert.fail;
 
 public class TestCheckReleaseNotesTask
@@ -33,6 +34,7 @@ public class TestCheckReleaseNotesTask
             .put("missing_section_header_1.txt", false)
             .put("missing_section_header_2.txt", false)
             .put("missing_section_header_3.txt", false)
+            .put("prestissimo_header.txt", true)
             .put("no_release_note.txt", true)
             .put("no_release_notes.txt", true)
             .put("release_notes_1.txt", true)
@@ -67,6 +69,31 @@ public class TestCheckReleaseNotesTask
         }
     }
 
+    @DataProvider(name = "validSectionHeaders")
+    public Object[][] sectionHeaders()
+    {
+        return new Object[][] {
+                {"General"},
+                {"Prestissimo (Native Execution)"},
+                {"Security"},
+                {"JDBC Driver"},
+                {"Web UI"},
+                {"Sample Connector"},
+                {"Verifier"},
+                {"Resource Groups"},
+                {"SPI"},
+                {"Sample Plugin"},
+                {"Documentation"},
+        };
+    }
+
+    @Test(dataProvider = "validSectionHeaders")
+    public void testValidReleaseNoteSections(String header)
+    {
+        String prDescription = format("== RELEASE NOTES ==\n\n%s\n* Add a change", header);
+        checkReleaseNotesTask.checkReleaseNotes(prDescription);
+    }
+
     @DataProvider(name = "releaseNotesFailures")
     public Object[][] releaseNotesFailures()
             throws IOException
@@ -91,12 +118,12 @@ public class TestCheckReleaseNotesTask
                 {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSNI changes\n* Add an SPI thing"},
                 // multiple sections one invalid release note verb
                 {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing"},
+                {"== RELEASE NOTES ==\n\nPrestissimo Native Execution Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing"},
         };
     }
 
     @Test(expectedExceptions = RuntimeException.class, dataProvider = "releaseNotesFailures")
     public void testInvalidReleaseNotes(String notes)
-            throws IOException
     {
         checkReleaseNotesTask.checkReleaseNotes(notes);
     }

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/prestissimo_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/prestissimo_header.txt
@@ -1,0 +1,22 @@
+Description
+Add a github action to enforce adding release notes and that they follow our documentation guidelines.
+Motivation and Context
+Significantly reduces work required in the release process, allowing us to adopt a faster release cadence
+Impact
+N/A
+Test Plan
+N/A
+Contributor checklist
+
+ Please make sure your submission complies with our contributing guide, in particular code style and commit standards.
+ PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
+ Documented new properties (with its default value), SQL syntax, functions, or other functionality.
+ If release notes are required, they follow the release notes guidelines.
+ Adequate tests were added if applicable.
+ CI passed.
+
+Release Notes
+== RELEASE NOTES ==
+
+Prestissimo (Native Execution) Changes
+* Improve error handling of INTERVAL DAY, INTERVAL HOUR, and INTERVAL SECOND operators when experiencing overflows.


### PR DESCRIPTION
This needed to be changed because the check was failing for headers with `Prestissimo (Native Execution)`