### PR TITLE
Migrate maven publishing service from OSSRH to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dep.airlift.version>0.188</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.testng.version>6.10</dep.testng.version>
-        <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
+        <dep.central-publishing.version>0.8.0</dep.central-publishing.version>
     </properties>
 
     <modules>
@@ -176,13 +176,14 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${dep.nexus-staging-plugin.version}</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${dep.central-publishing.version}</version>
                     <extensions>true</extensions>
                     <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <publishingServerId>ossrh</publishingServerId>
+                        <autoPublish>true</autoPublish>
+                        <waitUntil>validated</waitUntil>
                     </configuration>
                 </plugin>
             </plugins>
@@ -195,8 +196,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
By the OSSRH Sunset Notice on https://central.sonatype.org/publish/publish-maven/

The legacy OSSRH publishing service will be sunset on June 30th, 2025. This documentation is for informational purposes and will be removed at that time. If you are currently publishing via this service, please migrate to the new [Central Portal Publisher Service](https://central.sonatype.org/publish/publish-portal-guide/).