### PR TITLE
[fix] Update the re pattern for the release notes section

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -85,7 +85,10 @@ public class GenerateReleaseNotesTask
 
     private static final Pattern IGNORED_COMMITS_PATTERN = Pattern.compile("\\[maven-release-plugin]|add release note(s)? for|prepare for next development iteration", CASE_INSENSITIVE);
     protected static final Pattern NO_RELEASE_NOTE_PATTERN = Pattern.compile("== no release note(s)? ==", CASE_INSENSITIVE);
-    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\w*(.*)$", CASE_INSENSITIVE + MULTILINE + DOTALL);
+    // Matches release notes section and stops capturing before "Summary by" footer (added by bots like Sourcery)
+    // Pattern: "== release note(s)? ==" followed by optional whitespace and newline, then captures content
+    // until it encounters "\nSummary by" or reaches end of string
+    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\w*\\n?((?:(?!\\nSummary by).)*)", CASE_INSENSITIVE + MULTILINE + DOTALL);
     protected static final Pattern HEADER_PATTERN = Pattern.compile("(.*) change(s)$", CASE_INSENSITIVE);
     public static final List<Pattern> VALID_SECTION_HEADERS = ImmutableList.of(
                     "^General.*",

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
@@ -39,6 +39,8 @@ public class TestCheckReleaseNotesTask
             .put("no_release_notes.txt", true)
             .put("release_notes_1.txt", true)
             .put("release_notes_2.txt", true)
+            .put("release_notes_with_trailing_content.txt", true)
+            .put("release_notes_same_line.txt", true)
             .build();
 
     private CheckReleaseNotesTask checkReleaseNotesTask = new CheckReleaseNotesTask();

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_same_line.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_same_line.txt
@@ -1,0 +1,5 @@
+== RELEASE NOTES == General changes
+* Add support for inline release notes
+
+Summary by Sourcery
+This should not be included in the release notes.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_trailing_content.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_trailing_content.txt
@@ -1,0 +1,17 @@
+Description
+This PR fixes a critical issue.
+
+Release Notes
+Please follow release notes guidelines and fill in the release notes below.
+
+== RELEASE NOTES ==
+
+General Changes
+* Fix listing tables after rename to return fresh table metadata.
+
+Summary by Sourcery
+
+Clean up stale MongoDB table metadata when listing tables.
+
+Bug Fixes:
+- Ensure getAllTables returns only existing MongoDB collections.


### PR DESCRIPTION
Since the description may contain the `Summary by Sourcery` at the end, adjust the re pattern to accommondate this situation. The negative lookahead (?!\nSummary by) only stops when it encounters "\nSummary by". If that pattern doesn't exist, it continues to the end just like the old pattern.