### PR TITLE
[fix] Add missing name for publishing

### DIFF
--- a/presto-release-tools/pom.xml
+++ b/presto-release-tools/pom.xml
@@ -7,6 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>presto-release-tools</name>
     <artifactId>presto-release-tools</artifactId>
     <description>Presto Release Tool</description>
 


### PR DESCRIPTION
Publish failed with error:

```log
Deployment 965a8aad-3949-40ac-88f7-8d5438596181 failed
pkg:maven/com.facebook.presto/presto-release-tools@0.13:
 - Project name is missing
```