### PR TITLE
[fix] Add release notes summary to a file when it is too big

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,11 @@ jobs:
           git checkout ${{ env.RELEASE_VERSION }}
           git log --pretty="format:%ce: %s" -4
           cat ~/.m2/settings.xml
-          mvn deploy -Pdeploy-to-ossrh -DautoReleaseAfterClose=true
+          if [ "${{ vars.MOCK_PUBLISHING }}" = "true" ]; then
+            mvn deploy -Pdeploy-to-ossrh -DautoReleaseAfterClose=true || echo "Deploy failed but continuing due to MOCK_PUBLISHING=true"
+          else
+            mvn deploy -Pdeploy-to-ossrh -DautoReleaseAfterClose=true
+          fi
         env:
           NEXUS_USERNAME: "${{ secrets.NEXUS_USERNAME }}"
           NEXUS_PASSWORD: "${{ secrets.NEXUS_PASSWORD }}"

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -192,7 +192,38 @@ public class GenerateReleaseNotesTask
 
         log.info("Generating release notes pull request");
         String releaseNotesBranch = "release-notes-" + version.getVersion();
-        createReleaseNotesCommit(version.getVersion(), releaseNotesBranch, releaseNotes);
+
+        // Create full summary with footer
+        String fullSummary = releaseNotesSummary + RELEASE_NOTES_FOOTER;
+
+        // Check if body exceeds GitHub's limit and handle accordingly
+        String prBody;
+        boolean summaryFileCreated = false;
+        final int githubPrBodyLimit = 65000; // Use 65000 to leave some buffer
+
+        if (fullSummary.length() > githubPrBodyLimit) {
+            log.info("PR body exceeds GitHub limit (%d chars), creating summary file", fullSummary.length());
+            summaryFileCreated = true;
+
+            // Create truncated version with reference to full file
+            String truncationMessage = format(
+                    "\n\n\n**Note:** The full release notes summary was too large (%d characters) for GitHub's PR body limit.\n" +
+                    "The complete summary has been saved to [`release-notes-missing-%s.md`](../blob/release-notes-%s/release-notes-missing-%s.md) in this pull request.\n" +
+                    "**Please delete this file before merging.**\n",
+                    fullSummary.length(),
+                    version.getVersion(),
+                    version.getVersion(),
+                    version.getVersion());
+
+            int availableSpace = Math.max(0, githubPrBodyLimit - truncationMessage.length() - RELEASE_NOTES_FOOTER.length() - 100);
+            String truncatedSummary = releaseNotesSummary.substring(0, Math.min(availableSpace, releaseNotesSummary.length()));
+            prBody = truncatedSummary + RELEASE_NOTES_FOOTER + truncationMessage;
+        }
+        else {
+            prBody = fullSummary;
+        }
+
+        createReleaseNotesCommit(version.getVersion(), releaseNotesBranch, releaseNotes, summaryFileCreated ? Optional.of(fullSummary) : Optional.empty());
         git.push(ORIGIN, releaseNotesBranch, false);
 
         String originName = repository.getOriginName();
@@ -205,7 +236,7 @@ public class GenerateReleaseNotesTask
                 "master",
                 format("%s:%s", originRepo.split("/")[0], releaseNotesBranch),
                 format("docs: Add release notes for %s", version.getVersion()),
-                releaseNotesSummary + RELEASE_NOTES_FOOTER);
+                prBody);
         log.info("Release notes pull request created: %s", releaseNotesPullRequest.getUrl());
     }
 
@@ -419,7 +450,7 @@ public class GenerateReleaseNotesTask
                         .collect(joining("\n"));
     }
 
-    private void createReleaseNotesCommit(String version, String branch, String releaseNotes)
+    private void createReleaseNotesCommit(String version, String branch, String releaseNotes, Optional<String> fullSummary)
     {
         git.checkout(Optional.empty(), Optional.of(branch));
 
@@ -429,6 +460,13 @@ public class GenerateReleaseNotesTask
             List<String> lines = new LinkedList<>(asCharSource(Paths.get(gitDirectory, RELEASE_NOTES_LIST_FILE).toFile(), UTF_8).readLines());
             lines.add(7, format("    Release-%s [%tF] <release/release-%s>", version, new Date(), version));
             asCharSink(Paths.get(gitDirectory, RELEASE_NOTES_LIST_FILE).toFile(), UTF_8).write(Joiner.on("\n").join(lines) + "\n");
+
+            // Write full summary to file if it was too large for PR body
+            if (fullSummary.isPresent()) {
+                String summaryFileName = format("release-notes-missing-%s.md", version);
+                asCharSink(Paths.get(gitDirectory, summaryFileName).toFile(), UTF_8).write(fullSummary.get());
+                log.info("Created full summary file: %s", summaryFileName);
+            }
         }
         catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This PR fixed the error when geneating release notes by adding the summary to a file with name `release-notes-missing-<version>.md` under presto root folder, release owner need to remove this file before the release notes PR is meges.

```
2026-03-31T15:32:30.556Z	INFO	main	com.facebook.presto.release.AbstractCommands	Finished running command: git remote get-url origin
2026-03-31T15:32:30.556Z	INFO	main	com.facebook.presto.release.tasks.GenerateReleaseNotesTask	origin url: https://github.com/unix280/presto, repo: unix280/presto
2026-03-31T15:32:31.214Z	INFO	main	com.facebook.airlift.bootstrap.LifeCycleManager	Life cycle stopping...
2026-03-31T15:32:31.219Z	INFO	main	com.facebook.airlift.bootstrap.LifeCycleManager	Life cycle stopped.
2026-03-31T15:32:31.219Z	ERROR	main	Bootstrap	Uncaught exception in thread main
java.lang.RuntimeException: GraphQL error: [{type=UNPROCESSABLE, path=[createPullRequest], locations=[{line=2, column=5}], message=Body is too long (maximum is 65536 characters)}]
	at com.facebook.presto.release.git.GithubGraphQlAction.githubApi(GithubGraphQlAction.java:236)
	at com.facebook.presto.release.git.GithubGraphQlAction.createPullRequest(GithubGraphQlAction.java:205)
	at com.facebook.presto.release.tasks.GenerateReleaseNotesTask.run(GenerateReleaseNotesTask.java:203)
	at com.facebook.presto.release.tasks.AbstractReleaseCommand.run(AbstractReleaseCommand.java:50)
	at com.facebook.presto.release.PrestoReleaseService.main(PrestoReleaseService.java:43)
```

Tested with:
1. Release action in presto-release-tools  => https://github.com/unix280/presto-release-tools/actions/runs/23812204200/job/69401985641
2. Prepare release action in presto => https://github.com/unix280/presto/actions/runs/23812844511
3. Release notes PR => https://github.com/unix280/presto/pull/52
4. Release notes missing list file => https://github.com/unix280/presto/blob/release-notes-0.297/release-notes-missing-0.297.md