### PR TITLE
Fix release notes parser to handle bot-generated content

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -88,7 +88,7 @@ public class GenerateReleaseNotesTask
     // Matches release notes section and stops capturing before "Summary by" footer (added by bots like Sourcery)
     // Pattern: "== release note(s)? ==" followed by optional whitespace and newline, then captures content
     // until it encounters "\nSummary by" or reaches end of string
-    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\w*\\n?((?:(?!\\nSummary by).)*)", CASE_INSENSITIVE + MULTILINE + DOTALL);
+    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\w*\\n?(.*?)(?=\\s*Summary by|\\z)", CASE_INSENSITIVE + MULTILINE + DOTALL);
     protected static final Pattern HEADER_PATTERN = Pattern.compile("(.*) change(s)$", CASE_INSENSITIVE);
     public static final List<Pattern> VALID_SECTION_HEADERS = ImmutableList.of(
                     "^General.*",

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
@@ -41,6 +41,7 @@ public class TestCheckReleaseNotesTask
             .put("release_notes_2.txt", true)
             .put("release_notes_with_trailing_content.txt", true)
             .put("release_notes_same_line.txt", true)
+            .put("release_notes_with_sourcery_bot.txt", true)
             .build();
 
     private CheckReleaseNotesTask checkReleaseNotesTask = new CheckReleaseNotesTask();

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_sourcery_bot.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_sourcery_bot.txt
@@ -1,0 +1,48 @@
+  Motivation and Context
+  
+  
+  Impact
+  
+  Test Plan
+  
+  Contributor checklist
+  
+   Please make sure your submission complies with our contributing guide, in particular code style and commit standards.
+   PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
+   Documented new properties (with its default value), SQL syntax, functions, or other functionality.
+   If release notes are required, they follow the release notes guidelines.
+   Adequate tests were added if applicable.
+   CI passed.
+   If adding new dependencies, verified they have an OpenSSF Scorecard score of 5.0 or higher (or obtained explicit TSC approval for lower scores).
+  
+  Release Notes
+  Please follow release notes guidelines and fill in the release notes below.
+  == RELEASE NOTES ==
+  
+  Postgresql Connector Changes
+  * Add view support for the presto postgresql connector
+  
+  Summary by Sourcery
+  Add PostgreSQL-specific JDBC metadata to support connector-level view operations.
+  New Features:
+  
+  Enable listing, retrieving, creating, and dropping PostgreSQL views through the Presto PostgreSQL connector.
+  
+  Enhancements:
+  
+  Introduce a PostgreSQL-specific JdbcMetadata implementation and extend the base JDBC metadata factory to instantiate it when using the PostgreSQL client.
+  
+  Summary by Sourcery
+  Add PostgreSQL-specific JDBC metadata and client support to manage views through the PostgreSQL connector.
+  New Features:
+  
+  Enable creating, replacing, dropping, listing, and reading PostgreSQL views via the Presto PostgreSQL connector.
+  
+  Enhancements:
+  
+  Introduce a PostgreSqlMetadata implementation wired from JdbcMetadataFactory to add PostgreSQL-specific view handling.
+  Extend PostgreSqlClient with helpers to discover view schemas, list views, and translate PostgreSQL view definitions into Presto view metadata.
+  
+  Tests:
+  
+  Add PostgreSQL integration tests covering view creation, replacement, deletion, listing, and querying across a variety of SQL patterns and types.


### PR DESCRIPTION
The regex pattern was greedy and incorrectly captured bot-generated 'Summary by Sourcery' content within release notes sections. This caused the parser to fail with 'expect section header' errors.

Changes:
- Changed regex from greedy to reluctant quantifier (.*?)
- Replaced negative lookahead with positive lookahead for clarity
- Added \s* to handle optional whitespace before 'Summary by'
- Pattern now stops before any bot-generated content

The fix maintains backward compatibility with all existing test cases while correctly handling PRs with bot-generated summaries.

Test coverage:
- Added test case for Sourcery bot content
- All 36 TestCheckReleaseNotesTask tests pass
- All TestGenerateReleaseNotesTask tests pass
- No regressions detected