### PR TITLE
fix: use code block delimiters to find end of release notes

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/GithubGraphQlAction.java
@@ -73,7 +73,7 @@ public class GithubGraphQlAction
             "                                      number\n" +
             "                                      title\n" +
             "                                      url\n" +
-            "                                      bodyText\n" +
+            "                                      body\n" +
             "                                      author {\n" +
             "                                          login\n" +
             "                                      }\n" +
@@ -100,7 +100,7 @@ public class GithubGraphQlAction
             "            number\n" +
             "            title\n" +
             "            url\n" +
-            "            bodyText\n" +
+            "            body\n" +
             "            author {\n" +
             "                login\n" +
             "            }\n" +

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/git/PullRequest.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/git/PullRequest.java
@@ -35,7 +35,7 @@ public class PullRequest
             @JsonProperty("number") int id,
             @JsonProperty("title") String title,
             @JsonProperty("url") String url,
-            @JsonProperty("bodyText") String description,
+            @JsonProperty("body") String description,
             @JsonProperty("author") Actor author,
             @JsonProperty("mergedBy") User mergedBy)
     {

--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -72,7 +72,6 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.DOTALL;
-import static java.util.regex.Pattern.MULTILINE;
 import static java.util.stream.Collectors.joining;
 
 public class GenerateReleaseNotesTask
@@ -85,10 +84,7 @@ public class GenerateReleaseNotesTask
 
     private static final Pattern IGNORED_COMMITS_PATTERN = Pattern.compile("\\[maven-release-plugin]|add release note(s)? for|prepare for next development iteration", CASE_INSENSITIVE);
     protected static final Pattern NO_RELEASE_NOTE_PATTERN = Pattern.compile("== no release note(s)? ==", CASE_INSENSITIVE);
-    // Matches release notes section and stops capturing before "Summary by" footer (added by bots like Sourcery)
-    // Pattern: "== release note(s)? ==" followed by optional whitespace and newline, then captures content
-    // until it encounters "\nSummary by" or reaches end of string
-    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\w*\\n?((?:(?!\\nSummary by).)*)", CASE_INSENSITIVE + MULTILINE + DOTALL);
+    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\s*```[^\\n]*\\n(.*?)\\s*```", CASE_INSENSITIVE | DOTALL);
     protected static final Pattern HEADER_PATTERN = Pattern.compile("(.*) change(s)$", CASE_INSENSITIVE);
     public static final List<Pattern> VALID_SECTION_HEADERS = ImmutableList.of(
                     "^General.*",
@@ -254,7 +250,7 @@ public class GenerateReleaseNotesTask
             return Optional.of(ImmutableList.of());
         }
 
-        Matcher matcher = RELEASE_NOTE_PATTERN.matcher(pullRequest.getDescription() + "\n");
+        Matcher matcher = RELEASE_NOTE_PATTERN.matcher(pullRequest.getDescription());
         if (!matcher.find()) {
             log.warn("Pull request description does not match release note pattern");
             return Optional.empty();
@@ -266,7 +262,7 @@ public class GenerateReleaseNotesTask
         StringBuilder currentNote = null;
         ExtractionStatus status = EXPECT_SECTION_HEADER;
 
-        for (String line : Splitter.on("\n").trimResults().split(matcher.group(2))) {
+        for (String line : Splitter.on("\n").trimResults().split(matcher.group(2) + "\n")) {
             switch (status) {
                 case EXPECT_SECTION_HEADER:
                     if (line.isEmpty()) {

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
@@ -41,6 +41,7 @@ public class TestCheckReleaseNotesTask
             .put("release_notes_2.txt", true)
             .put("release_notes_with_trailing_content.txt", true)
             .put("release_notes_same_line.txt", true)
+            .put("release_notes_with_differential_revision.txt", true)
             .build();
 
     private CheckReleaseNotesTask checkReleaseNotesTask = new CheckReleaseNotesTask();
@@ -92,8 +93,21 @@ public class TestCheckReleaseNotesTask
     @Test(dataProvider = "validSectionHeaders")
     public void testValidReleaseNoteSections(String header)
     {
-        String prDescription = format("== RELEASE NOTES ==\n\n%s\n* Add a change", header);
+        String prDescription = format("== RELEASE NOTES ==\n```\n%s\n* Add a change\n```", header);
         checkReleaseNotesTask.checkReleaseNotes(prDescription);
+    }
+
+    @Test(dataProvider = "validSectionHeaders")
+    public void testValidReleaseNoteSectionsWithLanguageSpecifier(String header)
+    {
+        String prDescription = format("== RELEASE NOTES ==\n```markdown\n%s\n* Add a change\n```", header);
+        checkReleaseNotesTask.checkReleaseNotes(prDescription);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testReleaseNotesWithoutCodeFenceAreRejected()
+    {
+        checkReleaseNotesTask.checkReleaseNotes("== RELEASE NOTES ==\n\nGeneral Changes\n* Add a change");
     }
 
     @DataProvider(name = "releaseNotesFailures")
@@ -104,23 +118,27 @@ public class TestCheckReleaseNotesTask
                 // no edit to template
                 {Resources.toString(Resources.getResource("note_template.md"), StandardCharsets.UTF_8)},
                 // ambiguous, double release note blocks
-                {"== RELEASE NOTES ==\n changes\n* asdasd\n\n\n== NO RELEASE NOTES =="},
+                {"== RELEASE NOTES ==\n```\n changes\n* asdasd\n```\n\n== NO RELEASE NOTES =="},
                 // release note vs notes
-                {"== RELEASE NOTES ==\ngeneral\n* asd\n\n== RELEASE NOTE ==\ngeneral\n* asd"},
-                {"== RELEASE NOTES ==\ngeneral\n* asd\n\n== RELEASE NOTES ==\ngeneral\n* asd"},
+                {"== RELEASE NOTES ==\n```\ngeneral\n* asd\n```\n\n== RELEASE NOTE ==\n```\ngeneral\n* asd\n```"},
+                {"== RELEASE NOTES ==\n```\ngeneral\n* asd\n```\n\n== RELEASE NOTES ==\n```\ngeneral\n* asd\n```"},
+                // unterminated code fence
+                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add a change"},
                 // invalid section titles
-                {"== RELEASE NOTES ==\n\ngenerel chang\ntest"},
-                {"== RELEASE NOTES ==\n\ngeneral changes\ntest"},
-                {"== RELEASE NOTES ==\n\ncustom section\n* test"},
+                {"== RELEASE NOTES ==\n```\ngenerel chang\ntest\n```"},
+                // invalid section title with language-specified code fence
+                {"== RELEASE NOTES ==\n```markdown\ngenerel chang\ntest\n```"},
+                {"== RELEASE NOTES ==\n```\ngeneral changes\ntest\n```"},
+                {"== RELEASE NOTES ==\n```\ncustom section\n* test\n```"},
                 // invalid note starts
-                {"== RELEASE NOTES ==\n\nGeneral Changes\n* test a thing"},
-                {"== RELEASE NOTES ==\n\nGeneral Changes\ntest a thing"},
-                {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n* enhance a thing"},
+                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* test a thing\n```"},
+                {"== RELEASE NOTES ==\n```\nGeneral Changes\ntest a thing\n```"},
+                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add test a thing\n* enhance a thing\n```"},
                 // multiple sections, one invalid section title
-                {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSNI changes\n* Add an SPI thing"},
+                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add test a thing\n\nSNI changes\n* Add an SPI thing\n```"},
                 // multiple sections one invalid release note verb
-                {"== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing"},
-                {"== RELEASE NOTES ==\n\nPrestissimo Native Execution Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing"},
+                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing\n```"},
+                {"== RELEASE NOTES ==\n```\nPrestissimo Native Execution Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing\n```"},
         };
     }
 

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestGenerateReleaseNotesTask.java
@@ -111,6 +111,7 @@ public class TestGenerateReleaseNotesTask
             .addAll(createCommits("missing section header 3", USER1, USER1, true, 1))
             .addAll(createCommits("missing asterisk", USER3, USER2, true, 1))
             .addAll(createCommits("disassociated commit", USER3, USER2, false, 1))
+            .addAll(createCommits("release notes with differential revision", USER1, USER2, true, 1))
             .build();
 
     private File workingDirectory;

--- a/presto-release-tools/src/test/resources/git/github_create_pr_success.json
+++ b/presto-release-tools/src/test/resources/git/github_create_pr_success.json
@@ -5,7 +5,7 @@
         "number": 12345,
         "title": "Test PR Title",
         "url": "https://github.com/test/repo/pull/12345",
-        "bodyText": "Test PR Body",
+        "body": "Test PR Body",
         "author": {
           "login": "testuser"
         }

--- a/presto-release-tools/src/test/resources/git/github_create_pr_warning.json
+++ b/presto-release-tools/src/test/resources/git/github_create_pr_warning.json
@@ -5,7 +5,7 @@
         "number": 12345,
         "title": "Test PR Title",
         "url": "https://github.com/test/repo/pull/12345",
-        "bodyText": "Test PR Body",
+        "body": "Test PR Body",
         "author": {
           "login": "testuser"
         }

--- a/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/description_expected.txt
@@ -22,6 +22,8 @@
   - Remove unused FilterVoidLambda interface in ArrayFilterFunction.
   - Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
   - Improve the ``ConnectorMetadata#commitPartition`` operation. Change it into an async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``.
+- #10 (Author: A Brown): release notes with differential revision
+  - Fix an issue with query planning for certain join conditions.
 
 # All Commits
 - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01 release notes 1 - commit #1 (A Brown)
@@ -37,6 +39,7 @@
 - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11 missing section header 3 - commit #1 (A Brown)
 - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa12 missing asterisk - commit #1 (E Fisher)
 - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa13 disassociated commit - commit #1 (E Fisher)
+- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa14 release notes with differential revision - commit #1 (A Brown)
 
 ## Release Notes
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_asterisk.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_asterisk.txt
@@ -1,4 +1,5 @@
 == RELEASE NOTES ==
-
+```
 General Changes
 added configs to use common HTTPS settings for internal communications
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_1.txt
@@ -1,8 +1,9 @@
 Some PR description.
 
 == RELEASE NOTES ==
-
+```
 * Introduced new cache module to allow using local disk for to cache files from remote file systems.
 
 Raptor Changes
 * Allow Raptor to read data from HDFS while caching the files on local disks.
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_2.txt
@@ -1,8 +1,9 @@
 Some PR description.
 
 == RELEASE NOTES ==
-
+```
 Cache Changes
 * Introduced new cache module to allow using local disk for to cache files from remote file systems.
 
 * Allow Raptor to read data from HDFS while caching the files on local disks.
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_3.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/missing_section_header_3.txt
@@ -1,6 +1,7 @@
 Some PR description.
 
 == RELEASE NOTES ==
-
+```
 Introduced new cache module to allow using local disk for to cache files from remote file systems.
 Allow Raptor to read data from HDFS while caching the files on local disks.
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/prestissimo_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/prestissimo_header.txt
@@ -17,6 +17,7 @@ Contributor checklist
 
 Release Notes
 == RELEASE NOTES ==
-
+```
 Prestissimo (Native Execution) Changes
 * Improve error handling of INTERVAL DAY, INTERVAL HOUR, and INTERVAL SECOND operators when experiencing overflows.
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
@@ -1,7 +1,8 @@
 == RELEASE NOTES ==
-
+```
 Raptor Plugin Changes
 * Improve ``storage.data-directory` type. Changes the type from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
 * Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.
 * Fix an issue where DATE_TRUNC may produce incorrect results at certain timestamp in America/Sao_Paulo.
 * Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
@@ -1,5 +1,5 @@
 == RELEASE NOTES ==
-
+```
 Raptor Plugin Changes
 --------------
 * Improve correctness check for RowType columns.
@@ -9,3 +9,4 @@ Raptor Plugin Changes
 SPI Changes
 -----------
 * Improve the ``ConnectorMetadata#commitPartition`` operation. Change it into an async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_same_line.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_same_line.txt
@@ -1,5 +1,8 @@
-== RELEASE NOTES == General changes
+== RELEASE NOTES ==
+```
+General changes
 * Add support for inline release notes
+```
 
 Summary by Sourcery
 This should not be included in the release notes.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_differential_revision.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_differential_revision.txt
@@ -1,0 +1,7 @@
+== RELEASE NOTES ==
+```
+General Changes
+* Fix an issue with query planning for certain join conditions.
+```
+
+Differential Revision: D101554110

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_trailing_content.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_trailing_content.txt
@@ -5,9 +5,10 @@ Release Notes
 Please follow release notes guidelines and fill in the release notes below.
 
 == RELEASE NOTES ==
-
+```
 General Changes
 * Fix listing tables after rename to return fresh table metadata.
+```
 
 Summary by Sourcery
 

--- a/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
+++ b/presto-release-tools/src/test/resources/release-notes-test/release-0.231_expected.rst
@@ -11,6 +11,10 @@ Release 0.231
 **Details**
 ===========
 
+General Changes
+_______________
+* Fix an issue with query planning for certain join conditions. `#10 <https://github.com/prestodb/presto/pull/10>`_
+
 SPI Changes
 ___________
 * Improve the ``ConnectorMetadata#commitPartition`` operation. Change it into an async operation, and rename it to ``ConnectorMetadata#commitPartitionAsync``. `#2 <https://github.com/prestodb/presto/pull/2>`_


### PR DESCRIPTION
Release notes are not found when automation appends content after the release note section, such as "Differential Revision: D..." lines from Meta-exported diffs or "Summary by Sourcery" footers.

Previously the parser consumed everything after the == RELEASE NOTES == marker to the end of the PR description, so any trailing content was fed into the release note state machine and caused parse failures.

Now the parser reads the raw markdown body and uses the closing ``` fence of the code block to find the end of the release notes. This matches the format already specified in the PR template, and cleanly excludes any content that appears after the code block.

Release notes that are not wrapped in a code block are no longer supported.

Issue: https://github.com/prestodb/presto/issues/27654