### PR TITLE
Fix release note checker to match PR template format

### DIFF
--- a/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
+++ b/presto-release-tools/src/main/java/com/facebook/presto/release/tasks/GenerateReleaseNotesTask.java
@@ -83,8 +83,8 @@ public class GenerateReleaseNotesTask
     public static final String RELEASE_NOTES_LIST_FILE = "presto-docs/src/main/sphinx/release.rst";
 
     private static final Pattern IGNORED_COMMITS_PATTERN = Pattern.compile("\\[maven-release-plugin]|add release note(s)? for|prepare for next development iteration", CASE_INSENSITIVE);
-    protected static final Pattern NO_RELEASE_NOTE_PATTERN = Pattern.compile("== no release note(s)? ==", CASE_INSENSITIVE);
-    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("== release note(s)? ==\\s*```[^\\n]*\\n(.*?)\\s*```", CASE_INSENSITIVE | DOTALL);
+    protected static final Pattern NO_RELEASE_NOTE_PATTERN = Pattern.compile("```[^\\n]*\\s*== no release note(s)? ==\\s*```", CASE_INSENSITIVE | DOTALL);
+    protected static final Pattern RELEASE_NOTE_PATTERN = Pattern.compile("```[^\\n]*\\s*== release note(s)? ==\\s*\\n(.*?)\\s*```", CASE_INSENSITIVE | DOTALL);
     protected static final Pattern HEADER_PATTERN = Pattern.compile("(.*) change(s)$", CASE_INSENSITIVE);
     public static final List<Pattern> VALID_SECTION_HEADERS = ImmutableList.of(
                     "^General.*",

--- a/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
+++ b/presto-release-tools/src/test/java/com/facebook/presto/release/tasks/TestCheckReleaseNotesTask.java
@@ -42,6 +42,10 @@ public class TestCheckReleaseNotesTask
             .put("release_notes_with_trailing_content.txt", true)
             .put("release_notes_same_line.txt", true)
             .put("release_notes_with_differential_revision.txt", true)
+            .put("release_notes_with_whitespace_before_header.txt", true)
+            .put("release_notes_with_spaces_before_header.txt", true)
+            .put("no_release_note_with_whitespace_before_header.txt", true)
+            .put("no_release_note_with_spaces_before_header.txt", true)
             .build();
 
     private CheckReleaseNotesTask checkReleaseNotesTask = new CheckReleaseNotesTask();
@@ -93,14 +97,14 @@ public class TestCheckReleaseNotesTask
     @Test(dataProvider = "validSectionHeaders")
     public void testValidReleaseNoteSections(String header)
     {
-        String prDescription = format("== RELEASE NOTES ==\n```\n%s\n* Add a change\n```", header);
+        String prDescription = format("```\n== RELEASE NOTES ==\n\n%s\n* Add a change\n```", header);
         checkReleaseNotesTask.checkReleaseNotes(prDescription);
     }
 
     @Test(dataProvider = "validSectionHeaders")
     public void testValidReleaseNoteSectionsWithLanguageSpecifier(String header)
     {
-        String prDescription = format("== RELEASE NOTES ==\n```markdown\n%s\n* Add a change\n```", header);
+        String prDescription = format("```markdown\n== RELEASE NOTES ==\n\n%s\n* Add a change\n```", header);
         checkReleaseNotesTask.checkReleaseNotes(prDescription);
     }
 
@@ -118,27 +122,29 @@ public class TestCheckReleaseNotesTask
                 // no edit to template
                 {Resources.toString(Resources.getResource("note_template.md"), StandardCharsets.UTF_8)},
                 // ambiguous, double release note blocks
-                {"== RELEASE NOTES ==\n```\n changes\n* asdasd\n```\n\n== NO RELEASE NOTES =="},
+                {"```\n== RELEASE NOTES ==\n\n changes\n* asdasd\n```\n\n```\n== NO RELEASE NOTES ==\n```"},
                 // release note vs notes
-                {"== RELEASE NOTES ==\n```\ngeneral\n* asd\n```\n\n== RELEASE NOTE ==\n```\ngeneral\n* asd\n```"},
-                {"== RELEASE NOTES ==\n```\ngeneral\n* asd\n```\n\n== RELEASE NOTES ==\n```\ngeneral\n* asd\n```"},
-                // unterminated code fence
-                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add a change"},
+                {"```\n== RELEASE NOTES ==\n\ngeneral\n* asd\n```\n\n```\n== RELEASE NOTE ==\n\ngeneral\n* asd\n```"},
+                {"```\n== RELEASE NOTES ==\n\ngeneral\n* asd\n```\n\n```\n== RELEASE NOTES ==\n\ngeneral\n* asd\n```"},
+                // unterminated code fence for RELEASE NOTES
+                {"```\n== RELEASE NOTES ==\n\nGeneral Changes\n* Add a change"},
+                // unterminated code fence for NO RELEASE NOTES
+                {"```\n== NO RELEASE NOTES =="},
                 // invalid section titles
-                {"== RELEASE NOTES ==\n```\ngenerel chang\ntest\n```"},
+                {"```\n== RELEASE NOTES ==\n\ngenerel chang\ntest\n```"},
                 // invalid section title with language-specified code fence
-                {"== RELEASE NOTES ==\n```markdown\ngenerel chang\ntest\n```"},
-                {"== RELEASE NOTES ==\n```\ngeneral changes\ntest\n```"},
-                {"== RELEASE NOTES ==\n```\ncustom section\n* test\n```"},
+                {"```markdown\n== RELEASE NOTES ==\n\ngenerel chang\ntest\n```"},
+                {"```\n== RELEASE NOTES ==\n\ngeneral changes\ntest\n```"},
+                {"```\n== RELEASE NOTES ==\n\ncustom section\n* test\n```"},
                 // invalid note starts
-                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* test a thing\n```"},
-                {"== RELEASE NOTES ==\n```\nGeneral Changes\ntest a thing\n```"},
-                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add test a thing\n* enhance a thing\n```"},
+                {"```\n== RELEASE NOTES ==\n\nGeneral Changes\n* test a thing\n```"},
+                {"```\n== RELEASE NOTES ==\n\nGeneral Changes\ntest a thing\n```"},
+                {"```\n== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n* enhance a thing\n```"},
                 // multiple sections, one invalid section title
-                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add test a thing\n\nSNI changes\n* Add an SPI thing\n```"},
+                {"```\n== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSNI changes\n* Add an SPI thing\n```"},
                 // multiple sections one invalid release note verb
-                {"== RELEASE NOTES ==\n```\nGeneral Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing\n```"},
-                {"== RELEASE NOTES ==\n```\nPrestissimo Native Execution Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing\n```"},
+                {"```\n== RELEASE NOTES ==\n\nGeneral Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing\n```"},
+                {"```\n== RELEASE NOTES ==\n\nPrestissimo Native Execution Changes\n* Add test a thing\n\nSPI changes\n* bump version of an SPI thing\n```"},
         };
     }
 

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_note_with_spaces_before_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_note_with_spaces_before_header.txt
@@ -1,5 +1,4 @@
-Some PR description.
-
 ```
+   
 == NO RELEASE NOTE ==
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_note_with_whitespace_before_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_note_with_whitespace_before_header.txt
@@ -1,5 +1,5 @@
-Some PR description.
-
 ```
+
+
 == NO RELEASE NOTE ==
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_notes.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/no_release_notes.txt
@@ -1,1 +1,3 @@
+```
 == NO RELEASE NOTES ==
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/prestissimo_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/prestissimo_header.txt
@@ -16,8 +16,9 @@ Contributor checklist
  CI passed.
 
 Release Notes
-== RELEASE NOTES ==
 ```
+== RELEASE NOTES ==
+
 Prestissimo (Native Execution) Changes
 * Improve error handling of INTERVAL DAY, INTERVAL HOUR, and INTERVAL SECOND operators when experiencing overflows.
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_1.txt
@@ -1,5 +1,6 @@
-== RELEASE NOTES ==
 ```
+== RELEASE NOTES ==
+
 Raptor Plugin Changes
 * Improve ``storage.data-directory` type. Changes the type from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
 * Rename error code from ``RAPTOR_LOCAL_FILE_SYSTEM_ERROR`` to ``RAPTOR_FILE_SYSTEM_ERROR``.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_2.txt
@@ -1,5 +1,6 @@
-== RELEASE NOTES ==
 ```
+== RELEASE NOTES ==
+
 Raptor Plugin Changes
 --------------
 * Improve correctness check for RowType columns.

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_same_line.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_same_line.txt
@@ -1,5 +1,6 @@
-== RELEASE NOTES ==
 ```
+== RELEASE NOTES ==
+
 General changes
 * Add support for inline release notes
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_differential_revision.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_differential_revision.txt
@@ -1,5 +1,6 @@
-== RELEASE NOTES ==
 ```
+== RELEASE NOTES ==
+
 General Changes
 * Fix an issue with query planning for certain join conditions.
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_spaces_before_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_spaces_before_header.txt
@@ -1,0 +1,7 @@
+```
+   
+== RELEASE NOTES ==
+
+General Changes
+* Add a change with spaces before header
+```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_trailing_content.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_trailing_content.txt
@@ -4,8 +4,9 @@ This PR fixes a critical issue.
 Release Notes
 Please follow release notes guidelines and fill in the release notes below.
 
-== RELEASE NOTES ==
 ```
+== RELEASE NOTES ==
+
 General Changes
 * Fix listing tables after rename to return fresh table metadata.
 ```

--- a/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_whitespace_before_header.txt
+++ b/presto-release-tools/src/test/resources/release-notes-test/pr/release_notes_with_whitespace_before_header.txt
@@ -1,0 +1,7 @@
+```
+
+== RELEASE NOTES ==
+
+General Changes
+* Add a change with extra newlines before header
+```


### PR DESCRIPTION
The release note checker's regex patterns expected '== RELEASE NOTES ==' to be outside the triple backticks, but the PR template has it inside.

Changes:
- Updated RELEASE_NOTE_PATTERN and NO_RELEASE_NOTE_PATTERN in GenerateReleaseNotesTask.java to expect headers inside backticks
- Made patterns flexible to handle optional whitespace/newlines before headers using \s* (matches spaces, tabs, newlines)
- Updated all existing test resource files to use new format
- Added 4 new test cases to verify flexible whitespace handling
- Updated TestCheckReleaseNotesTask.java with new test cases

Confirm the implementation now
correctly matches the PR template format at:
https://github.com/prestodb/presto/blob/master/pull_request_template.md